### PR TITLE
Remove zstd compressed packages when building or cleaning.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,7 @@ pkgbuild() {
     # Clean up the package folder
     rm -rf "./$1/src" "./$1/pkg"
     rm -f "./$1/"*.pkg.tar.xz "./$1/"*.pkg.tar.xz.sig
+    rm -f "./$1/"*.pkg.tar.zstd "./$1/"*.pkg.tar.zstd.sig
 
     # makepkg options:
     # -s (--syncdeps): Install missing dependencies

--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -52,6 +52,7 @@ needs_install() {
 build() {
     rm -rf "./$1/src" "./$1/pkg"
     rm -f "./$1/"*.pkg.tar.xz "./$1/"*.pkg.tar.xz.sig
+    rm -f "./$1/"*.pkg.tar.zstd "./$1/"*.pkg.tar.zstd.sig
     (cd "./$1" && shift && makepkg -s -C --noconfirm "$@") || exit $?
 }
 

--- a/clean.sh
+++ b/clean.sh
@@ -9,6 +9,8 @@ cd "$(dirname -- "$0")"
 rm -frv ./*/src/ ./*/pkg/
 rm -fv ./*/*.pkg.tar.xz
 rm -fv ./*/*.pkg.tar.xz.sig
+rm -fv ./*/*.pkg.tar.zstd
+rm -fv ./*/*.pkg.tar.zstd.sig
 rm -fv ./*/*.src.tar.gz
 rm -fv ./*/*.log
 


### PR DESCRIPTION
Change is required due to the transition to the new compression format