### PR TITLE
pam-selinux update to 1.4.0-1 and a resulting GPG keyserver issue fix

### DIFF
--- a/pam-selinux/PKGBUILD
+++ b/pam-selinux/PKGBUILD
@@ -1,4 +1,3 @@
-# $Id$
 # Maintainer: Tobias Powalowski <tpowa@archlinux.org>
 # Contributor: judd <jvinet@zeroflux.org>
 # SELinux Maintainer: Nicolas Iooss (nicolas <dot> iooss <at> m4x <dot> org)
@@ -9,7 +8,7 @@
 # If you want to help keep it up to date, please open a Pull Request there.
 
 pkgname=pam-selinux
-pkgver=1.3.1
+pkgver=1.4.0
 pkgrel=1
 pkgdesc="SELinux aware PAM (Pluggable Authentication Modules) library"
 arch=('x86_64')
@@ -25,11 +24,13 @@ groups=('selinux')
 source=(https://github.com/linux-pam/linux-pam/releases/download/v$pkgver/Linux-PAM-$pkgver.tar.xz
         https://github.com/linux-pam/linux-pam/releases/download/v$pkgver/Linux-PAM-$pkgver.tar.xz.asc)
 validpgpkeys=(
-        '8C6BFD92EE0F42EDF91A6A736D1A7F052E5924BB' # Thorsten Kukuk
+	'296D6F29A020808E8717A8842DB5BD89A340AEB7' # Dmitry V. Levin
 )
 
-md5sums=('558ff53b0fc0563ca97f79e911822165'
-         'SKIP')
+sha256sums=(
+	'cd6d928c51e64139be3bdb38692c68183a509b83d4f2c221024ccd4bcddfd034'
+        'SKIP'
+)
 
 options=('!emptydirs')
 

--- a/pam-selinux/PKGBUILD
+++ b/pam-selinux/PKGBUILD
@@ -9,7 +9,7 @@
 
 pkgname=pam-selinux
 pkgver=1.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="SELinux aware PAM (Pluggable Authentication Modules) library"
 arch=('x86_64')
 license=('GPL2')
@@ -24,13 +24,11 @@ groups=('selinux')
 source=(https://github.com/linux-pam/linux-pam/releases/download/v$pkgver/Linux-PAM-$pkgver.tar.xz
         https://github.com/linux-pam/linux-pam/releases/download/v$pkgver/Linux-PAM-$pkgver.tar.xz.asc)
 validpgpkeys=(
-	'296D6F29A020808E8717A8842DB5BD89A340AEB7' # Dmitry V. Levin
+	'296D6F29A020808E8717A8842DB5BD89A340AEB7' # Dmitry V. Levin <ldv@altlinux.org>
 )
 
-sha256sums=(
-	'cd6d928c51e64139be3bdb38692c68183a509b83d4f2c221024ccd4bcddfd034'
-        'SKIP'
-)
+sha256sums=('cd6d928c51e64139be3bdb38692c68183a509b83d4f2c221024ccd4bcddfd034'
+            'SKIP')
 
 options=('!emptydirs')
 

--- a/selinux-refpolicy-git/PKGBUILD
+++ b/selinux-refpolicy-git/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=selinux-refpolicy-git
 _policyname=refpolicy-git
-pkgver=RELEASE_2_20190201.r0.g10e0106e825b
+pkgver=RELEASE_2_20200229.r271.gaa6c3f4d
 pkgrel=1
 pkgdesc="Modular SELinux reference policy including headers and docs"
 arch=('any')


### PR DESCRIPTION
Pam-selinux failed to build, so updated pam-selinux package to new version, which now builds and installs succesfully. The new GPG key that was used to sign updated pam-selinux was not found from the keyserver defined in `recv_gpg_keys.sh`. Changed the keyserver in said script to point to OpenPGP Keyserver to cover more ground.