### PR TITLE
Moved python-setuptools from makedepends to depends

### DIFF
--- a/setools/PKGBUILD
+++ b/setools/PKGBUILD
@@ -25,10 +25,10 @@ groups=('selinux')
 arch=('i686' 'x86_64')
 url="https://github.com/SELinuxProject/setools/wiki"
 license=('GPL' 'LGPL')
-depends=('libsepol>=2.8' 'libselinux>=2.8' 'python' 'python-networkx>=2.0')
+depends=('libsepol>=2.8' 'libselinux>=2.8' 'python' 'python-networkx>=2.0' 'python-setuptools')
 optdepends=('python-pyqt5: needed for graphical tools'
             'qt5-tools: display apol help with Qt Assistant')
-makedepends=('cython' 'python-setuptools' 'python-tox')
+makedepends=('cython' 'python-tox')
 checkdepends=('checkpolicy')
 conflicts=("selinux-${pkgname}")
 provides=("selinux-${pkgname}=${pkgver}-${pkgrel}")


### PR DESCRIPTION
At least 'seinfo' needs this library.
While playing with a minimal system, I got the following error running 'seinfo' if python-setuptools is not installed.
```
[tqre@pacstrap-selinux:~]$ seinfo
Traceback (most recent call last):
  File "/usr/bin/seinfo", line 21, in <module>
    import setools
  File "/usr/lib/python3.8/site-packages/setools/__init__.py", line 79, in <module>
    from .permmap import PermissionMap
  File "/usr/lib/python3.8/site-packages/setools/permmap.py", line 26, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
After installing python-setuptools, all is well :)