### PR TITLE
Update to pambase-20200721.1-2

### DIFF
--- a/pambase-selinux/.SRCINFO
+++ b/pambase-selinux/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = pambase-selinux
 	pkgdesc = SELinux aware base PAM configuration for services
-	pkgver = 20190105.1
-	pkgrel = 1
+	pkgver = 20200721.1
+	pkgrel = 2
 	url = http://www.archlinux.org
 	arch = any
 	groups = selinux
 	license = GPL
-	provides = pambase=20190105.1-1
-	provides = selinux-pambase=20190105.1-1
+	provides = pambase=20200721.1-2
+	provides = selinux-pambase=20200721.1-2
 	conflicts = pambase
 	conflicts = selinux-pambase
 	backup = etc/pam.d/system-auth
@@ -22,9 +22,9 @@ pkgbase = pambase-selinux
 	source = system-remote-login
 	source = system-services
 	source = other
-	sha256sums = 3eb67872e436817ec97c4f3795adba2cf1d3829ea4e107ef5747569e4eeb5746
+	sha256sums = 89d62406b2d623a76d53c33aca98ce8ee124ed4a450ff6c8a44cfccca78baa2f
 	sha256sums = 005736b9bd650ff5e5d82a7e288853776d5bb8c90185d5774c07231c1e1c64a9
-	sha256sums = cba3b852839973a69ba27b1ae3933eb66a59fa5d3d157b8a12c1404f81a1a1f3
+	sha256sums = 5540c3b34e9c2344ddc55183015c2e0b9c6009b4248154db62f1e560d0d64d11
 	sha256sums = 005736b9bd650ff5e5d82a7e288853776d5bb8c90185d5774c07231c1e1c64a9
 	sha256sums = 6eb1acdd3fa9f71a7f93fbd529be57ea65bcafc6e3a98a06af4d88013fc6a567
 	sha256sums = d5ed59ec2157c19c87964a162f7ca84d53c19fb2bd68d3fbc1671ba8d906346f

--- a/pambase-selinux/PKGBUILD
+++ b/pambase-selinux/PKGBUILD
@@ -7,8 +7,8 @@
 # If you want to help keep it up to date, please open a Pull Request there.
 
 pkgname=pambase-selinux
-pkgver=20190105.1
-pkgrel=1
+pkgver=20200721.1
+pkgrel=2
 pkgdesc="SELinux aware base PAM configuration for services"
 arch=('any')
 url="http://www.archlinux.org"
@@ -29,9 +29,9 @@ backup=('etc/pam.d/system-auth'
         'etc/pam.d/system-remote-login'
         'etc/pam.d/system-services'
         'etc/pam.d/other')
-sha256sums=('3eb67872e436817ec97c4f3795adba2cf1d3829ea4e107ef5747569e4eeb5746'
+sha256sums=('89d62406b2d623a76d53c33aca98ce8ee124ed4a450ff6c8a44cfccca78baa2f'
             '005736b9bd650ff5e5d82a7e288853776d5bb8c90185d5774c07231c1e1c64a9'
-            'cba3b852839973a69ba27b1ae3933eb66a59fa5d3d157b8a12c1404f81a1a1f3'
+            '5540c3b34e9c2344ddc55183015c2e0b9c6009b4248154db62f1e560d0d64d11'
             '005736b9bd650ff5e5d82a7e288853776d5bb8c90185d5774c07231c1e1c64a9'
             '6eb1acdd3fa9f71a7f93fbd529be57ea65bcafc6e3a98a06af4d88013fc6a567'
             'd5ed59ec2157c19c87964a162f7ca84d53c19fb2bd68d3fbc1671ba8d906346f')

--- a/pambase-selinux/system-auth
+++ b/pambase-selinux/system-auth
@@ -1,16 +1,26 @@
 #%PAM-1.0
 
-auth      required  pam_unix.so     try_first_pass nullok
-auth      optional  pam_permit.so
-auth      required  pam_env.so
+auth       required                    pam_faillock.so      preauth
+# Optionally use requisite above if you do not want to prompt for the password
+# on locked accounts.
+auth       [success=2 default=ignore]  pam_unix.so          try_first_pass nullok
+-auth      [success=1 default=ignore]  pam_systemd_home.so
+auth       [default=die]               pam_faillock.so      authfail
+auth       optional                    pam_permit.so
+auth       required                    pam_env.so
+auth       required                    pam_faillock.so      authsucc
+# If you drop the above call to pam_faillock.so the lock will be done also
+# on non-consecutive authentication failures.
 
-account   required  pam_unix.so
-account   optional  pam_permit.so
-account   required  pam_time.so
+-account   [success=1 default=ignore]  pam_systemd_home.so
+account    required                    pam_unix.so
+account    optional                    pam_permit.so
+account    required                    pam_time.so
 
-password  required  pam_unix.so     try_first_pass nullok sha512 shadow
-password  optional  pam_permit.so
+-password  [success=1 default=ignore]  pam_systemd_home.so
+password   required                    pam_unix.so          try_first_pass nullok shadow
+password   optional                    pam_permit.so
 
-session   required  pam_limits.so
-session   required  pam_unix.so
-session   optional  pam_permit.so
+session    required                    pam_limits.so
+session    required                    pam_unix.so
+session    optional                    pam_permit.so

--- a/pambase-selinux/system-login
+++ b/pambase-selinux/system-login
@@ -1,11 +1,9 @@
 #%PAM-1.0
 
-auth       required   pam_tally2.so        onerr=succeed file=/var/log/tallylog
 auth       required   pam_shells.so
 auth       requisite  pam_nologin.so
 auth       include    system-auth
 
-account    required   pam_tally2.so 
 account    required   pam_access.so
 account    required   pam_nologin.so
 account    include    system-auth
@@ -22,4 +20,4 @@ session    required   pam_selinux.so open
 session    optional   pam_motd.so          motd=/etc/motd
 session    optional   pam_mail.so          dir=/var/spool/mail standard quiet
 -session   optional   pam_systemd.so
-session    required   pam_env.so
+session    required   pam_env.so           user_readenv=1


### PR DESCRIPTION
This goes together with pam 1.4.0 update. Review these changes once more as it is a critical package.
Builds and installs good (with pam 1.4.0).

Changes reflect the core PKGBUILD and files:
https://github.com/archlinux/svntogit-packages/tree/packages/pambase/trunk

This package (and vice versa) obviously requires pam >= 1.4.0, but I didn't add it yet to PKGBUILD as core packages don't have it. 