### PR TITLE
Fix on pam and pambase dependency chain and build script order

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,8 +51,8 @@ pkgbuild selinux-dbus-config
 pkgbuild selinux-sandbox
 
 # Build core packages with SELinux support
-pkgbuild pam-selinux
 pkgbuild pambase-selinux
+pkgbuild pam-selinux
 pkgbuild coreutils-selinux
 pkgbuild findutils-selinux
 pkgbuild iproute2-selinux

--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -182,8 +182,8 @@ install_libreport
 build_and_install selinux-alpm-hook
 
 # Core packages with SELinux support
-build_and_install pam-selinux
 build_and_install pambase-selinux
+build_and_install pam-selinux
 build_and_install coreutils-selinux
 build_and_install findutils-selinux
 build_and_install iproute2-selinux

--- a/build_cleanpkg.sh
+++ b/build_cleanpkg.sh
@@ -113,8 +113,8 @@ pkgbuild selinux-refpolicy-arch libsepol libselinux libsemanage semodule-utils c
 pkgbuild selinux-refpolicy-git libsepol libselinux libsemanage semodule-utils checkpolicy policycoreutils
 
 # Build core packages with SELinux support
-pkgbuild pam-selinux libsepol libselinux
-pkgbuild pambase-selinux pam-selinux
+pkgbuild pambase-selinux
+pkgbuild pam-selinux libsepol libselinux pambase-selinux
 pkgbuild coreutils-selinux libsepol libselinux
 pkgbuild findutils-selinux libsepol libselinux
 pkgbuild iproute2-selinux libsepol libselinux

--- a/pam-selinux/.SRCINFO
+++ b/pam-selinux/.SRCINFO
@@ -14,7 +14,7 @@ pkgbase = pam-selinux
 	depends = libtirpc
 	depends = audit
 	depends = libselinux
-	optdepends = pambase-selinux: SELinux aware base PAM configuration
+	depends = pambase-selinux
 	provides = pam=1.4.0-3
 	provides = selinux-pam=1.4.0-3
 	conflicts = pam

--- a/pam-selinux/PKGBUILD
+++ b/pam-selinux/PKGBUILD
@@ -14,9 +14,8 @@ pkgdesc="SELinux aware PAM (Pluggable Authentication Modules) library"
 arch=('x86_64')
 license=('GPL2')
 url="http://linux-pam.org"
-depends=('glibc' 'libtirpc' 'audit' 'libselinux')
+depends=('glibc' 'libtirpc' 'audit' 'libselinux' 'pambase-selinux')
 makedepends=('flex' 'w3m' 'docbook-xml>=4.4' 'docbook-xsl')
-optdepends=('pambase-selinux: SELinux aware base PAM configuration')
 conflicts=("${pkgname/-selinux}" "selinux-${pkgname/-selinux}")
 provides=("${pkgname/-selinux}=${pkgver}-${pkgrel}"
           "selinux-${pkgname/-selinux}=${pkgver}-${pkgrel}")

--- a/pambase-selinux/.SRCINFO
+++ b/pambase-selinux/.SRCINFO
@@ -6,11 +6,11 @@ pkgbase = pambase-selinux
 	arch = any
 	groups = selinux
 	license = GPL
-	depends = pam-selinux>=1.4.0
 	provides = pambase=20200721.1-2
 	provides = selinux-pambase=20200721.1-2
 	conflicts = pambase
 	conflicts = selinux-pambase
+	conflicts = pam-selinux<1.4.0
 	backup = etc/pam.d/system-auth
 	backup = etc/pam.d/system-local-login
 	backup = etc/pam.d/system-login

--- a/pambase-selinux/PKGBUILD
+++ b/pambase-selinux/PKGBUILD
@@ -14,8 +14,7 @@ arch=('any')
 url="https://www.archlinux.org"
 license=('GPL')
 groups=('selinux')
-depends=('pam-selinux>=1.4.0') # For module pam_faillock.so
-conflicts=("${pkgname/-selinux}" "selinux-${pkgname/-selinux}")
+conflicts=("${pkgname/-selinux}" "selinux-${pkgname/-selinux}" 'pam-selinux<1.4.0')
 provides=("${pkgname/-selinux}=${pkgver}-${pkgrel}"
           "selinux-${pkgname/-selinux}=${pkgver}-${pkgrel}")
 source=('system-auth'


### PR DESCRIPTION
I stumbled upon this while developing a PKGBUILD which is based on the idea of using base-selinux package instead of base when installing the system. The package allows to install Arch Linux right from the start with SELinux support, provided that there is a repository that serves the packages.

The PKGBUILD I'm working on plus a public repository address:
https://github.com/tqre/selinux/blob/base-selinux/base-selinux/PKGBUILD
http://selinux.tqre.fi/selinux-testing

If pam-selinux is installed without pambase-selinux, login is not possible due to missing files needed with pambase package. There was some dependency and build order shuffling earlier with issue #46 . The case of upgrading pambase before pam should not occur normally, as these packages are always coupled together. I can't think of a reasonable use case where this would actually happen.

Pam should have the dependency on pambase, and when a user updates the system, both packages are updated. It used to be optional dependency, which broke my setup and made me notice this.

This is also in line with core packages: pam has a dependency on pambase, while pambase itself has no dependencies. The whole dependency chain: base -> shadow -> pam -> pambase

https://github.com/archlinux/svntogit-packages/blob/packages/pambase/trunk/PKGBUILD  
https://github.com/archlinux/svntogit-packages/blob/packages/pam/trunk/PKGBUILD  

The build order should also be restored in build scripts. Effectively pambase contains only text-files, which can be safely built before pam itself.

NOTE: I have only tested build_and_install_all.sh -script, as I have no use for the others atm. They are reverted to their original form as they were before pam-upgrade.

I would like to see the base-selinux adopted here, but I'll make a separate post about it.