### PR TITLE
Base selinux - bootstrapping PKGBUILDs

### DIFF
--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -227,3 +227,20 @@ build_and_install selinux-refpolicy-arch
 
 # Refpolicy git master
 build_and_install selinux-refpolicy-git
+
+# Build base-selinux and base-devel-selinux meta packages
+
+# Dependency checks are skipped with -d flag as these packages are only lists
+# of packages that are to be installed. Also possible conflicts with the
+# original base and base-devel -packages is the reason these are only built
+# and not installed. Namely base-selinux is intended to be used when installing
+# Arch Linux, and base-devel-selinux takes care that sudo has selinux support.
+
+build_nodeps() {
+    rm -rf "./$1/src" "./$1/pkg"
+    rm -f "./$1/"*.pkg.tar.zst "./$1/"*.pkg.tar.zst.sig
+    (cd "./$1" && shift && makepkg -d -C --noconfirm "$@") || exit $?
+}
+
+build_nodeps base-selinux
+build_nodeps base-devel-selinux


### PR DESCRIPTION
Here are the `base` and `base-devel` meta packages modified for SELinux support. The base-selinux meta package allows for bootstrapping from ArchISO with `pacstrap /mnt base-selinux`. The base-devel -group has been also recreated as a meta package, as tools like sudo and openssh are compiled with SELinux support. I have only included the refpolicy-arch package for now to keep it as small as possible.

I have also added few lines to `build_and_install_all.sh` -script for these meta-packages to get built, which is the script I use within my build pipeline.

It only makes sense to have these packages if a public repository is available that serves them, so I have been maintaining one. I have added note of this to main README, and will make step-by-step instructions to ArchWiki at some point. 

So far it's been working as intended, although I haven't done extensive testing. I have succesfully installed on VM's and bare-metal machines, and my spare laptop runs Arch with SELinux support installed and kept up-to-date using these packages for over a month now.

Improvements and thoughts are most welcome.

