### PR TITLE
Change Docker image file and detect containers in build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # Build SELinux packages for Arch linux in Docker/Podman container
 
-# NOTE: docker build fails on systemd tests (20201207)
 # Usage:
-#    sudo docker build -t arch-selinux-build .
+#    docker build -t arch-selinux-build .
 # or   
 #    sudo podman build -t arch-selinux-build .
 #
 # Once the container is built, you can get the packages in "pkgs" directory with:
-#    sudo docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
+#    docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 # or
 #    podman run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build SELinux packages for Arch linux in Docker/Podman container
 
 # Usage:
-#    docker build -t arch-selinux-build .
+#    sudo docker build -t arch-selinux-build .
 # or   
-#    sudo podman build -t arch-selinux-build .
+#    podman build -t arch-selinux-build .
 #
 # Once the container is built, you can get the packages in "pkgs" directory with:
-#    docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
+#    sudo docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 # or
 #    podman run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@
 # or with Podman on Arch Linux in July 2020:
 #    podman --cgroup-manager=cgroupfs build -t arch-selinux-build .
 #
-# Once the container is build, you can get the packages in "pkgs" directory with:
+# Once the container is built, you can get the packages in "pkgs" directory with:
 #    sudo docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 # or
 #    podman run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 
-# Use official Arch Linux Docker image (https://hub.docker.com/_/archlinux)
-FROM archlinux:latest
+# Use official Arch Linux Docker image (https://hub.docker.com/r/archlinux/archlinux)
+FROM archlinux/archlinux:latest
 LABEL Description="Build SELinux packages for Arch Linux"
 
 COPY . /startdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
+# Build SELinux packages for Arch linux in Docker/Podman container
+
+# NOTE: docker build fails on systemd tests (20201207)
 # Usage:
 #    sudo docker build -t arch-selinux-build .
-#
-# or with Podman on Arch Linux in July 2020:
-#    podman --cgroup-manager=cgroupfs build -t arch-selinux-build .
+# or   
+#    sudo podman build -t arch-selinux-build .
 #
 # Once the container is built, you can get the packages in "pkgs" directory with:
 #    sudo docker run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
@@ -10,7 +12,7 @@
 #    podman run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 
 # Use official Arch Linux Docker image (https://hub.docker.com/r/archlinux/archlinux)
-FROM archlinux/archlinux:latest
+FROM docker.io/archlinux/archlinux:latest
 LABEL Description="Build SELinux packages for Arch Linux"
 
 COPY . /startdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@
 # or
 #    podman run -v "$(pwd)/pkgs:/packages" --rm -ti arch-selinux-build
 
-# Use official Arch Linux Docker image (https://hub.docker.com/r/archlinux/archlinux)
+# Use official Arch Linux Docker image:
+# https://gitlab.archlinux.org/archlinux/archlinux-docker
 FROM docker.io/archlinux/archlinux:latest
 LABEL Description="Build SELinux packages for Arch Linux"
 

--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -62,9 +62,7 @@ build() {
     rm -f "./$1/"*.pkg.tar.xz "./$1/"*.pkg.tar.xz.sig
     rm -f "./$1/"*.pkg.tar.zst "./$1/"*.pkg.tar.zst.sig
     # When building in a container, systemd's tests fail because of default Seccomp filters
-    if [ "$1" = 'systemd-selinux' ] && \
-        (systemd-detect-virt -q --container || systemd-detect-virt -q --private-users ) && \
-        grep '^Seccomp:\s*2$' /proc/self/status > /dev/null
+    if [ "$1" = 'systemd-selinux' ] && grep '^Seccomp:\s*2$' /proc/self/status > /dev/null
     then
         set -- "$@" --nocheck
     fi


### PR DESCRIPTION
Changed Docker image file to the more frequently updated archlinux/archlinux. I also added docker.io to front for better podman compatibility. Didn't test with podman yet fully.

Building packages in container failed because of systemd checks because the part in script build_and_install_all.sh that would have triggered to disable those checks didn't fire.

I've been looking at GitHub Actions to set up a CI pipeline, so I had to make these work first. So far so good with those:
https://github.com/tqre/selinux/actions/runs/406799585/workflow
