### PR TITLE
GitHub actions starter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ github-actions ]
+    branches: [ master ]
     paths:
     - 'Dockerfile'
     - 'build_and_install_all.sh'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           name: Arch Linux packages for SELinux support
           path: pkgs
 
-  test_packages_bootstrap_qemu:
+  test_packages_on_qemu:
     runs-on: ubuntu-latest
     needs: build_all_packages
     steps:
@@ -52,6 +52,7 @@ jobs:
           sudo parted -a optimal /dev/loop0 mkpart primary 0% 100%
           sudo parted /dev/loop0 set 1 boot on
           sudo mkfs.ext4 /dev/loop0p1
+          sudo tune2fs -L ROOT /dev/loop0p1
           sudo mount /dev/loop0p1 /tmp/arch
 
       - name: Get the SELinux packages
@@ -72,14 +73,42 @@ jobs:
             echo "Server = https://mirror.pkgbuild.com/\$repo/os/\$arch" >> /etc/pacman.d/mirrorlist;
             echo -e "[selinux-testing]\nSigLevel = Never\nServer = file:///var/cache/pacman/pkg" >> /etc/pacman.conf;
             repo-add /var/cache/pacman/pkg/selinux-testing.db.tar.xz /var/cache/pacman/pkg/*;
-            pacstrap /mnt base-selinux linux grub'
+            pacstrap /mnt base-selinux base-devel-selinux openssh-selinux linux grub;
+            genfstab -L /mnt >> /mnt/etc/fstab'
 
-      - name: Work on the loop mounted raw image
+      - name: Make testing configurations for the raw image
         run: |
           sudo /tmp/boots/usr/bin/arch-chroot /tmp/arch /bin/bash -c \
-           'ls -la;
-            cat /etc/pacman.d/mirrorlist;
-            lsblk'
+           'ln -sfv /usr/share/zoneinfo/UTC /etc/localtime;
+            hwclock --systohc;
+            sed -i 's/#en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen;
+            locale-gen;
+            echo LANG=en_US.UTF-8 > /etc/locale.conf;
+            echo qemu-arch-selinux > /etc/hostname;
+            echo -e "127.0.0.1 localhost\n::1 localhost" > /etc/hosts;
+            echo -e "[Match]\nName=en*\n[Network]\nDHCP=ipv4" > /etc/systemd/network/dhcp.network;
+            systemctl enable systemd-networkd.service;
+            sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config;
+            sed -i "s/#PermitEmptyPasswords no/PermitEmptyPasswords yes/" /etc/ssh/sshd_config;
+            systemctl enable sshd;
+            sed -i 's/root:x:/root::/' /etc/passwd;
+            grub-install --target=i386-pc /dev/loop0;
+            sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/' /etc/default/grub;
+            sed -i '/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"' /etc/default/grub;
+            grub-mkconfig -o /boot/grub/grub.cfg'
 
+      - name: Unmount loops and convert the QEMU image to qcow2
+        run: |
+          sudo umount /tmp/boots/mnt
+          sudo umount /tmp/arch
+          sudo losetup -d /dev/loop0
+          qemu-img convert -f raw -O qcow2 archlinux.raw archlinux.qcow2
 
+      - name: Run configurations and tests with the image
+        run: |
+          qemu-system-x86_64 archlinux.qcow2 \
+            -net nic -net user,hostfwd=tcp::10022-:22 \
+            -nographic -m 2048 &
+          sleep 30
+          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'restorecon -R /; sestatus'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,13 @@ name: Build
 on:
   push:
     branches: [ github-actions ]
+    paths:
+    - 'Dockerfile'
+    - 'build_and_install_all.sh'
+    - 'clean.sh'
+    - 'recv_gpg_keys.sh'
+    - '*/PKGBUILD'
+    - '.github/workflows/main.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           mkdir -v repo /tmp/{boots,arch}
 
       - name: Download latest ArchISO bootstrap image
-        run: curl https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-2020.12.01-x86_64.tar.gz --output archbootstrap.tar.gz
+        run: curl https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-$(date +"%Y.%m.01")-x86_64.tar.gz --output archbootstrap.tar.gz
 
       - name: Create new raw image for Arch Linux and mount it as a loop device
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and install Arch Linux's SELinux support packages in a docker container
         run: docker build -t arch-selinux-build .
+      - name: Run the container - built packages are transferred to build host
+        run: docker run -v "$(pwd)/pkgs:/packages" --rm arch-selinux-build
+      - name: Upload packages as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Arch Linux packages for SELinux support
+          path: pkgs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Build all packages
+
+on:
+  push:
+    branches: [ github-actions ]
+  workflow_dispatch:
+
+jobs:
+  build_all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and install Arch Linux's SELinux support packages in a docker container
+        run: docker build -t arch-selinux-build .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ on:
       - master
       - github-actions
     paths:
-    - 'Dockerfile'
-    - 'build_and_install_all.sh'
-    - 'clean.sh'
-    - 'recv_gpg_keys.sh'
-    - '*/PKGBUILD'
-    - '.github/workflows/main.yml'
+      - 'Dockerfile'
+      - 'build_and_install_all.sh'
+      - 'clean.sh'
+      - 'recv_gpg_keys.sh'
+      - '*/PKGBUILD'
+      - '.github/workflows/main.yml'
   workflow_dispatch:
 
 jobs:
@@ -44,9 +44,6 @@ jobs:
       - name: Download latest ArchISO bootstrap image
         run: curl https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-2020.12.01-x86_64.tar.gz --output archbootstrap.tar.gz
 
-      - name: Extract the archlinux-bootstrap to a directory
-        run: sudo tar xf archbootstrap.tar.gz -C /tmp/boots --strip-components 1
-
       - name: Create new raw image for Arch Linux and mount it as a loop device
         run: |
           qemu-img create -f raw archlinux.raw 8G
@@ -58,17 +55,16 @@ jobs:
           sudo tune2fs -L ROOT /dev/loop0p1
           sudo mount /dev/loop0p1 /tmp/arch
 
-      - name: Get the SELinux packages
+      - name: Get the SELinux packages from build job
         uses: actions/download-artifact@v2
         with:
           name: Arch Linux packages for SELinux support
           path: repo
 
-      - name: Copy the SELinux packages to bootstrap mount
-        run: sudo cp -v repo/* /tmp/boots/var/cache/pacman/pkg
-
-      - name: Chroot into the arch-bootstrap directory and install Arch with SELinux support to loop mounted raw image
+      - name: Prepare arch-bootstrap directory, chroot into it and install Arch with SELinux support to loop-mounted raw image
         run: |
+          sudo tar xf archbootstrap.tar.gz -C /tmp/boots --strip-components 1
+          sudo cp -v repo/* /tmp/boots/var/cache/pacman/pkg
           sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -c \
            'pacman-key --init;
             pacman-key --populate archlinux;
@@ -100,14 +96,14 @@ jobs:
             sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"security=selinux selinux=1 console=ttyS0\"" /etc/default/grub;
             grub-mkconfig -o /boot/grub/grub.cfg'
 
-      - name: Unmount loops and convert the QEMU image to qcow2
+      - name: Unmount loop devices and convert the QEMU image to qcow2
         run: |
           sudo umount /tmp/boots/mnt
           sudo umount /tmp/arch
           sudo losetup -d /dev/loop0
           qemu-img convert -f raw -O qcow2 archlinux.raw archlinux.qcow2
 
-      - name: Run configurations and tests with the image
+      - name: Run test commands on the image
         run: |
           qemu-system-x86_64 archlinux.qcow2 \
             -net nic -net user,hostfwd=tcp::10022-:22 \
@@ -137,9 +133,8 @@ jobs:
           tag_name: ArchLinux-SELinux
           files: packages/*
           body: |
-            Arch Linux packages to enable SELinux support
+            # Arch Linux packages to enable SELinux support
             https://wiki.archlinux.org/index.php/SELinux
-
             ```
             ${{ github.event.head_commit.message }}
             ```

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
   build_all_packages:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Build and install Arch Linux's SELinux support packages in a docker container
         run: docker build -t arch-selinux-build .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build_all_packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
@@ -33,7 +33,7 @@ jobs:
           path: pkgs
 
   test_packages_on_qemu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: build_all_packages
     steps:
       - name: Install QEMU to the runner and make needed directories
@@ -112,7 +112,7 @@ jobs:
           ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'restorecon -Rv /; ls -laZ /; sestatus'
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: test_packages_on_qemu
     if: github.ref == 'refs/heads/github-actions' || github.ref == 'refs/heads/master'
     steps:
@@ -134,7 +134,9 @@ jobs:
           files: packages/*
           body: |
             # Arch Linux packages to enable SELinux support
-            https://wiki.archlinux.org/index.php/SELinux
+            https://wiki.archlinux.org/index.php/SELinux  
+
+            Latest commit:
             ```
             ${{ github.event.head_commit.message }}
             ```

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,13 +112,13 @@ jobs:
           qemu-system-x86_64 archlinux.qcow2 \
             -net nic -net user,hostfwd=tcp::10022-:22 \
             -nographic -m 2048 &
-          sleep 30
-          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'ls -laZ; restorecon -R /; sestatus'
+          sleep 25
+          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'restorecon -Rv /; ls -laZ /; sestatus'
 
   release:
     runs-on: ubuntu-latest
     needs: test_packages_on_qemu
-    if: github.ref == 'refs/heads/github-actions'
+    if: github.ref == 'refs/heads/github-actions' || github.ref == 'refs/heads/master'
     steps:
       - name: Get packages from build artifacts
         uses: actions/download-artifact@v2
@@ -136,6 +136,13 @@ jobs:
         with:
           tag_name: ArchLinux-SELinux
           files: packages/*
+          body: |
+            Arch Linux packages to enable SELinux support
+            https://wiki.archlinux.org/index.php/SELinux
+
+            ```
+            ${{ github.event.head_commit.message }}
+            ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,12 @@ jobs:
   build_all_packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Build and install Arch Linux's SELinux support packages in a docker container
         run: docker build -t arch-selinux-build .
+
       - name: Run the container - built packages are transferred to build host
         run: docker run -v "$(pwd)/pkgs:/packages" --rm arch-selinux-build
+
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -94,7 +95,7 @@ jobs:
             sed -i 's/root:x:/root::/' /etc/passwd;
             grub-install --target=i386-pc /dev/loop0;
             sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/' /etc/default/grub;
-            sed -i '/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"' /etc/default/grub;
+            sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"security=selinux selinux=1 console=ttyS0\"" /etc/default/grub;
             grub-mkconfig -o /boot/grub/grub.cfg'
 
       - name: Unmount loops and convert the QEMU image to qcow2
@@ -110,5 +111,29 @@ jobs:
             -net nic -net user,hostfwd=tcp::10022-:22 \
             -nographic -m 2048 &
           sleep 30
-          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'restorecon -R /; sestatus'
+          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'ls -laZ; restorecon -R /; sestatus'
 
+  release:
+    runs-on: ubuntu-latest
+    needs: test_packages_on_qemu
+    if: github.ref == 'refs/heads/github-actions'
+    steps:
+      - name: Get packages from build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: Arch Linux packages for SELinux support
+          path: packages
+
+      - name: Remove old release
+        uses: ame-yu/action-delete-latest-release@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release all packages
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ArchLinux-SELinux
+          files: packages/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - github-actions
     paths:
     - 'Dockerfile'
     - 'build_and_install_all.sh'
@@ -26,3 +28,58 @@ jobs:
         with:
           name: Arch Linux packages for SELinux support
           path: pkgs
+
+  test_packages_bootstrap_qemu:
+    runs-on: ubuntu-latest
+    needs: build_all_packages
+    steps:
+      - name: Install QEMU to the runner and make needed directories
+        run: |
+          sudo apt-get install qemu
+          mkdir -v repo /tmp/{boots,arch}
+
+      - name: Download latest ArchISO bootstrap image
+        run: curl https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-2020.12.01-x86_64.tar.gz --output archbootstrap.tar.gz
+
+      - name: Extract the archlinux-bootstrap to a directory
+        run: sudo tar xf archbootstrap.tar.gz -C /tmp/boots --strip-components 1
+
+      - name: Create new raw image for Arch Linux and mount it as a loop device
+        run: |
+          qemu-img create -f raw archlinux.raw 8G
+          sudo losetup --show -f -P archlinux.raw
+          sudo parted /dev/loop0 mklabel msdos
+          sudo parted -a optimal /dev/loop0 mkpart primary 0% 100%
+          sudo parted /dev/loop0 set 1 boot on
+          sudo mkfs.ext4 /dev/loop0p1
+          sudo mount /dev/loop0p1 /tmp/arch
+
+      - name: Get the SELinux packages
+        uses: actions/download-artifact@v2
+        with:
+          name: Arch Linux packages for SELinux support
+          path: repo
+
+      - name: Copy the SELinux packages to bootstrap mount
+        run: sudo cp -v repo/* /tmp/boots/var/cache/pacman/pkg
+
+      - name: Chroot into the arch-bootstrap directory and install Arch with SELinux support to loop mounted raw image
+        run: |
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -c \
+           'pacman-key --init;
+            pacman-key --populate archlinux;
+            mount /dev/loop0p1 /mnt;
+            echo "Server = https://mirror.pkgbuild.com/\$repo/os/\$arch" >> /etc/pacman.d/mirrorlist;
+            echo -e "[selinux-testing]\nSigLevel = Never\nServer = file:///var/cache/pacman/pkg" >> /etc/pacman.conf;
+            repo-add /var/cache/pacman/pkg/selinux-testing.db.tar.xz /var/cache/pacman/pkg/*;
+            pacstrap /mnt base-selinux linux grub'
+
+      - name: Work on the loop mounted raw image
+        run: |
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/arch /bin/bash -c \
+           'ls -la;
+            cat /etc/pacman.d/mirrorlist;
+            lsblk'
+
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build all packages
+name: Build
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_all:
+  build_all_packages:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![build](https://github.com/tqre/selinux/workflows/Build/badge.svg)
+
 PKGBUILDs for SELinux support in Arch Linux
 ===========================================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![build](https://github.com/tqre/selinux/workflows/Build/badge.svg)
+![build](https://github.com/archlinuxhardened/selinux/workflows/Build/badge.svg)
 
 PKGBUILDs for SELinux support in Arch Linux
 ===========================================


### PR DESCRIPTION
I have created a simple GitHub Actions workflow that builds the packages with docker using the Dockerfile we have. After the workflow has been completed, the build artifacts (*.pkg.tar.zst) are available for downloading as a one big zip file via the Actions tab and the relevant workflow run.

Ideas/features/issues:
- The workflow triggers when push is made to the workflow file itself, any PKGBUILD file, Dockerfile, or the scripts used in Dockerfile.
- workflow_dispatch enables manual triggering of the workflow.
- Artifact download link works only for users that are logged in.
- The workflow takes about 40 minutes to run. Maybe make workflows for individual packages?
- Further handling of artifacts into GitHub's releases / packages?

Example workflow run with artifact download link:
https://github.com/tqre/selinux/actions/runs/408409124

