### PR TITLE
Added testbuild tag to trigger Actions -pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-      - github-actions
+    tags:
+      - 'testbuild'
     paths:
       - 'Dockerfile'
       - 'build_and_install_all.sh'
@@ -114,7 +115,7 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     needs: test_packages_on_qemu
-    if: github.ref == 'refs/heads/github-actions' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Get packages from build artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - 'testbuild'
+      - testbuild*
     paths:
       - 'Dockerfile'
       - 'build_and_install_all.sh'


### PR DESCRIPTION
The 'testbuild' tag can be used to trigger the GitHub Actions workflow. It can
be used to build and run on any update, and the main point is that releases
are only created on pushes to the master branch.

Usage: create a tag and push a new branch with an update to a package
$ git tag testbuild-_package-version_
$ git push -u origin _branch_ testbuild-_package-version_

The testbuild-_package-version_ is the tag. The naming reflects also on the Actions -page:
https://github.com/tqre/selinux/actions/runs/490600535