### PR TITLE
Trigger GitHub Actions on all branches and Pull Requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,16 +2,7 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
-      - github-actions
-    paths:
-      - 'Dockerfile'
-      - 'build_and_install_all.sh'
-      - 'clean.sh'
-      - 'recv_gpg_keys.sh'
-      - '*/PKGBUILD'
-      - '.github/workflows/main.yml'
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -115,7 +106,7 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     needs: test_packages_on_qemu
-    if: github.ref == 'refs/heads/github-actions' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Get packages from build artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Build and test from everywhere, but only release when pushing to `master`, as suggested in https://github.com/archlinuxhardened/selinux/pull/76#issuecomment-763099105