### PR TITLE
GitHub actions improved: releases works as a repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           name: Arch Linux packages for SELinux support
           path: pkgs
 
-  test_packages_on_qemu:
+  prepare_testing:
     runs-on: ubuntu-18.04
     needs: build_all_packages
     steps:
@@ -95,24 +95,85 @@ jobs:
           sudo losetup -d /dev/loop0
           qemu-img convert -f raw -O qcow2 archlinux.raw archlinux.qcow2
 
+      - name: Upload VM to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Arch Linux VM with SELinux support
+          path: archlinux.qcow2 
+
+  test_SELinux_functionality:
+    runs-on: ubuntu-18.04
+    needs: prepare_testing
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install QEMU to the runner and make needed directories
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu
+
+      - name: Download VM artifact for testing
+        uses: actions/download-artifact@v2
+        with:
+          name: Arch Linux VM with SELinux support
+
+      - name: Use the initial VM image as a backing file
+        run: |
+          qemu-img create -f qcow2 -F qcow2 -b archlinux.qcow2 archselinux.qcow2
+
       - name: Run test commands on the image
         run: |
-          qemu-system-x86_64 archlinux.qcow2 \
+          qemu-system-x86_64 archselinux.qcow2 \
             -net nic -net user,hostfwd=tcp::10022-:22 \
             -nographic -m 2048 &
           sleep 25
           ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 'restorecon -Rv /; ls -laZ /; sestatus'
 
+      - name: Upload the qcow2 file containing VM image changes to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Arch Linux VM after tests and restorecon
+          path: archselinux.qcow2
+
+  prepare_release:
+    runs-on: ubuntu-18.04
+    needs: test_SELinux_functionality
+    if: github.ref == 'refs/heads/github-actions'
+    steps:
+      - name: Prepare Arch specific binaries for use
+        run: |
+          mkdir -v /tmp/boots
+          curl https://mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-$(date +"%Y.%m.01")-x86_64.tar.gz --output archbootstrap.tar.gz
+          sudo tar xf archbootstrap.tar.gz -C /tmp/boots --strip-components 1
+          mkdir -v /tmp/boots/repo
+
+      - name: Get the SELinux packages from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: Arch Linux packages for SELinux support
+          path: /tmp/boots/repo
+
+      - name: Create package repository files
+        run: |
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -c \
+           'repo-add /repo/selinux.db.tar.xz /repo/*'
+
+      - name: Upload the ready repository as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: SELinux pacman repository
+          path: /tmp/boots/repo
+
   release:
     runs-on: ubuntu-18.04
-    needs: test_packages_on_qemu
-    if: github.ref == 'refs/heads/master'
+    needs: prepare_release
+    if: github.ref == 'refs/heads/github-actions'
     steps:
       - name: Get packages from build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: Arch Linux packages for SELinux support
-          path: packages
+          name: SELinux pacman repository
+          path: release
 
       - name: Remove old release
         uses: ame-yu/action-delete-latest-release@v2
@@ -123,7 +184,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ArchLinux-SELinux
-          files: packages/*
+          files: release/*
           body: |
             # Arch Linux packages to enable SELinux support
             https://wiki.archlinux.org/index.php/SELinux  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
   prepare_release:
     runs-on: ubuntu-18.04
     needs: test_SELinux_functionality
-    if: github.ref == 'refs/heads/github-actions'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Prepare Arch specific binaries for use
         run: |
@@ -167,7 +167,7 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     needs: prepare_release
-    if: github.ref == 'refs/heads/github-actions'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Get packages from build artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Create new raw image for Arch Linux and mount it as a loop device
         run: |
-          qemu-img create -f raw archlinux.raw 8G
-          sudo losetup --show -f -P archlinux.raw
+          qemu-img create -f raw archselinux.raw 8G
+          sudo losetup --show -f -P archselinux.raw
           sudo parted /dev/loop0 mklabel msdos
           sudo parted -a optimal /dev/loop0 mkpart primary 0% 100%
           sudo parted /dev/loop0 set 1 boot on
@@ -93,13 +93,13 @@ jobs:
           sudo umount /tmp/boots/mnt
           sudo umount /tmp/arch
           sudo losetup -d /dev/loop0
-          qemu-img convert -f raw -O qcow2 archlinux.raw archlinux.qcow2
+          qemu-img convert -f raw -O qcow2 archselinux.raw archselinux.qcow2
 
       - name: Upload VM to artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Arch Linux VM with SELinux support
-          path: archlinux.qcow2 
+          path: archselinux.qcow2 
 
   test_SELinux_functionality:
     runs-on: ubuntu-18.04
@@ -119,11 +119,11 @@ jobs:
 
       - name: Use the initial VM image as a backing file
         run: |
-          qemu-img create -f qcow2 -F qcow2 -b archlinux.qcow2 archselinux.qcow2
+          qemu-img create -f qcow2 -F qcow2 -b archselinux.qcow2 archselinux_test.qcow2
 
       - name: Run test commands on the image
         run: |
-          qemu-system-x86_64 archselinux.qcow2 \
+          qemu-system-x86_64 archselinux_test.qcow2 \
             -net nic -net user,hostfwd=tcp::10022-:22 \
             -nographic -m 2048 &
           sleep 25
@@ -133,12 +133,11 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Arch Linux VM after tests and restorecon
-          path: archselinux.qcow2
+          path: archselinux_test.qcow2
 
   prepare_release:
     runs-on: ubuntu-18.04
     needs: test_SELinux_functionality
-    if: github.ref == 'refs/heads/master'
     steps:
       - name: Prepare Arch specific binaries for use
         run: |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ Authors are credited in the PKGBUILD file for each package.
 Binary repository
 -----------------
 
-An experimental binary repository is available at http://selinux.tqre.fi/selinux-testing  
-The packages are compiled with `build_and_install_all.sh` -script, and the repository can be used to install a fresh Arch Linux with SELinux support using `base-selinux` -meta package. The repository is not signed at the moment. The documentation will be available in ArchWiki soon.
+The releases page functions as a pacman repository. It can also be used when
+installing Arch Linux using `base-selinux` -package instead of plain `base`. 
+
+To use it, add the following lines to your `/etc/pacman.conf`:
+```
+[selinux]
+Server = https://github.com/archlinuxhardened/selinux/releases/download/ArchLinux-SELinux
+SigLevel = Never
+```
+While the repository remains unsigned, SigLevel has to be set to Never.
 
 Build order
 -----------

--- a/sudo-selinux/.SRCINFO
+++ b/sudo-selinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = sudo-selinux
 	pkgdesc = Give certain users the ability to run some commands as root - SELinux support
-	pkgver = 1.9.5.p1
+	pkgver = 1.9.5.p2
 	pkgrel = 1
 	url = https://www.sudo.ws/sudo/
 	install = sudo.install
@@ -13,20 +13,20 @@ pkgbase = sudo-selinux
 	depends = libldap
 	depends = zlib
 	depends = libselinux
-	provides = sudo=1.9.5.p1-1
-	provides = selinux-sudo=1.9.5.p1-1
+	provides = sudo=1.9.5.p2-1
+	provides = selinux-sudo=1.9.5.p2-1
 	conflicts = sudo
 	conflicts = selinux-sudo
 	backup = etc/pam.d/sudo
 	backup = etc/sudo.conf
 	backup = etc/sudo_logsrvd.conf
 	backup = etc/sudoers
-	source = https://www.sudo.ws/sudo/dist/sudo-1.9.5p1.tar.gz
-	source = https://www.sudo.ws/sudo/dist/sudo-1.9.5p1.tar.gz.sig
+	source = https://www.sudo.ws/sudo/dist/sudo-1.9.5p2.tar.gz
+	source = https://www.sudo.ws/sudo/dist/sudo-1.9.5p2.tar.gz.sig
 	source = sudo_logsrvd.service
 	source = sudo.pam
 	validpgpkeys = 59D1E9CCBA2B376704FDD35BA9F4C021CEA470FB
-	sha256sums = 4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882
+	sha256sums = 539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978
 	sha256sums = SKIP
 	sha256sums = 8b91733b73171827c360a3e01f4692772b78e62ceca0cf0fd4b770aba35081a1
 	sha256sums = d1738818070684a5d2c9b26224906aad69a4fea77aabd960fc2675aee2df1fa2

--- a/sudo-selinux/PKGBUILD
+++ b/sudo-selinux/PKGBUILD
@@ -9,9 +9,9 @@
 # If you want to help keep it up to date, please open a Pull Request there.
 
 pkgname=sudo-selinux
-_sudover=1.9.5p1
-pkgver=${_sudover/p/.p}
+_sudover=1.9.5p2
 pkgrel=1
+pkgver=${_sudover/p/.p}
 pkgdesc="Give certain users the ability to run some commands as root - SELinux support"
 arch=('x86_64')
 url="https://www.sudo.ws/sudo/"
@@ -29,7 +29,7 @@ install=${pkgname/-selinux}.install
 source=(https://www.sudo.ws/sudo/dist/${pkgname/-selinux}-$_sudover.tar.gz{,.sig}
         sudo_logsrvd.service
         sudo.pam)
-sha256sums=('4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882'
+sha256sums=('539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978'
             'SKIP'
             '8b91733b73171827c360a3e01f4692772b78e62ceca0cf0fd4b770aba35081a1'
             'd1738818070684a5d2c9b26224906aad69a4fea77aabd960fc2675aee2df1fa2')

--- a/sync_srcinfos.sh
+++ b/sync_srcinfos.sh
@@ -10,4 +10,11 @@ while read -r DIR
 do
     echo "Generating $DIR/.SRCINFO"
     (cd "$DIR" && updpkgsums && makepkg --printsrcinfo > .SRCINFO)
+
+    # For base-selinux and base-devel-selinux, updpkgsums introduces an blank
+    # line at the end of the file. Delete it.
+    if [ "$DIR" = ./base-devel-selinux ] || [ "$DIR" = ./base-selinux ]
+    then
+        sed '${/^$/d}' -i "$DIR/PKGBUILD"
+    fi
 done


### PR DESCRIPTION
I worked some on our CI/CD pipeline:

- The VM image is now an artifact that can be downloaded for inspection
- Tests are now a separated job, and the resulting VM is a qcow2 based on the first image - only changes are recorded
- The releases page works now as a pacman repository, instructions under 'Binary repository' on main README file
- Some naming changes and clarifications on descriptions

Here is a resulting releases page from my fork, the pacman database files are new:
https://github.com/tqre/selinux/releases/tag/ArchLinux-SELinux

And here is a link to artifacts (need to be signed in to GitHub to view):
https://github.com/tqre/selinux/actions/runs/507124264

I tested to bootstrap a fresh Arch with SELinux support straight from above page, and it works like a charm.

Some todos as a reminder for the future:
- sign the repo
- things still to work on from PR #67: .BUILDINFO packager and test commands/script

