### PR TITLE
Fix GitHub actions issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,20 +8,41 @@ on:
 jobs:
   build_all_packages:
     runs-on: ubuntu-18.04
+    container:
+      image: archlinux/archlinux:latest
+      options: --privileged
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Build and install Arch Linux's SELinux support packages in a docker container
-        run: docker build -t arch-selinux-build .
-
-      - name: Run the container - built packages are transferred to build host
-        run: docker run -v "$(pwd)/pkgs:/packages" --rm arch-selinux-build
+        run: |
+          mkdir -vp /startdir && \
+          cp -Rv . /startdir && \
+          pacman -q --noconfirm -Syu base base-devel expect git && \
+          pacman --noconfirm -Sc && \
+          rm -rf /var/cache/pacman/pkg/* && \
+          ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
+          useradd -g users -m builduser && \
+          echo 'builduser ALL=(ALL) NOPASSWD: /usr/bin/pacman' >> /etc/sudoers && \
+          echo 'builduser ALL=(ALL) NOPASSWD: /usr/bin/sh -c { pacman --noconfirm --ask=4 -U sudo-selinux/sudo-selinux-*.pkg.tar.zst && if test -e /etc/sudoers.pacsave ; then mv /etc/sudoers.pacsave /etc/sudoers ; fi }' >> /etc/sudoers && \
+          echo 'MAKEFLAGS="-j$(nproc)"' >> /etc/makepkg.conf && \
+          echo 'BUILDDIR=/build' >> /etc/makepkg.conf && \
+          echo 'LOGDEST=/logdest' >> /etc/makepkg.conf && \
+          mkdir -vp /packages /build /logdest && \
+          chown -R builduser /startdir /packages /build /logdest && \
+          sudo -u builduser /startdir/clean.sh && \
+          sudo -u builduser /startdir/recv_gpg_keys.sh && \
+          sudo -u builduser /startdir/build_and_install_all.sh && \
+          rm -rf /startdir/*/src/ /startdir/*/pkg/ && \
+          pacman --noconfirm -Sc && rm -rf /var/cache/pacman/pkg/* && \
+          cp /startdir/*/*.pkg.tar.zst /packages
 
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Arch Linux packages for SELinux support
-          path: pkgs
+          path: /packages
 
   prepare_testing:
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: archlinux/archlinux:latest
-      options: --privileged
+      options: --security-opt=seccomp=unconfined
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           sudo tar xf archbootstrap.tar.gz -C /tmp/boots --strip-components 1
           sudo cp -v repo/* /tmp/boots/var/cache/pacman/pkg
-          sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -c \
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -ex -c \
            'pacman-key --init;
             pacman-key --populate archlinux;
             mount /dev/loop0p1 /mnt;
@@ -90,7 +90,7 @@ jobs:
 
       - name: Make testing configurations for the raw image
         run: |
-          sudo /tmp/boots/usr/bin/arch-chroot /tmp/arch /bin/bash -c \
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/arch /bin/bash -ex -c \
            'ln -sfv /usr/share/zoneinfo/UTC /etc/localtime;
             hwclock --systohc;
             sed -i 's/#en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
             sed -i 's/root:x:/root::/' /etc/passwd;
             grub-install --target=i386-pc /dev/loop0;
             sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/' /etc/default/grub;
-            sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"security=selinux selinux=1 console=ttyS0\"" /etc/default/grub;
+            sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"lsm=lockdown,yama,selinux,bpf selinux=1 console=ttyS0\"" /etc/default/grub;
             grub-mkconfig -o /boot/grub/grub.cfg;
             restorecon -RF /'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,8 @@ jobs:
             grub-install --target=i386-pc /dev/loop0;
             sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/' /etc/default/grub;
             sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"security=selinux selinux=1 console=ttyS0\"" /etc/default/grub;
-            grub-mkconfig -o /boot/grub/grub.cfg'
+            grub-mkconfig -o /boot/grub/grub.cfg;
+            restorecon -RF /'
 
       - name: Unmount loop devices and convert the QEMU image to qcow2
         run: |

--- a/_vagrant/step1_install_and_configure.sh
+++ b/_vagrant/step1_install_and_configure.sh
@@ -72,18 +72,18 @@ systemctl enable restorecond.service
 # Configure the bootloader to launch SELinux kernel
 if [ -e /etc/default/grub ]
 then
-    if ! grep 'GRUB_CMDLINE_LINUX=".*selinux=1 security=selinux' /etc/default/grub > /dev/null
+    if ! grep 'GRUB_CMDLINE_LINUX=".*selinux=1 lsm=lockdown,yama,selinux,bpf' /etc/default/grub > /dev/null
     then
-        sed -i -e 's/\(GRUB_CMDLINE_LINUX="\)/\1selinux=1 security=selinux /' /etc/default/grub
+        sed -i -e 's/\(GRUB_CMDLINE_LINUX="\)/\1selinux=1 lsm=lockdown,yama,selinux,bpf /' /etc/default/grub
     fi
     grub-mkconfig -o /boot/grub/grub.cfg
 fi
 if [ -e /boot/syslinux/syslinux.cfg ]
 then
-    if ! grep 'APPEND .*selinux=1 security=selinux' /boot/syslinux/syslinux.cfg > /dev/null
+    if ! grep 'APPEND .*selinux=1 lsm=lockdown,yama,selinux,bpf' /boot/syslinux/syslinux.cfg > /dev/null
     then
         # Enable SELinux in kernel command line
-        sed -i -e 's:\(^\s*APPEND \):\1selinux=1 security=selinux :' /boot/syslinux/syslinux.cfg
+        sed -i -e 's:\(^\s*APPEND \):\1selinux=1 lsm=lockdown,yama,selinux,bpf :' /boot/syslinux/syslinux.cfg
     fi
 fi
 

--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -62,7 +62,7 @@ build() {
     rm -f "./$1/"*.pkg.tar.xz "./$1/"*.pkg.tar.xz.sig
     rm -f "./$1/"*.pkg.tar.zst "./$1/"*.pkg.tar.zst.sig
     # When building in a container, systemd's tests fail because of default Seccomp filters
-    if [ "$1" = 'systemd-selinux' ] && [ -f /.dockerenv ]
+    if [ "$1" = 'systemd-selinux' ] && (grep '^Seccomp:\s*2$' /proc/self/status > /dev/null || [ -f /.dockerenv ])
     then
         set -- "$@" --nocheck
     fi

--- a/build_and_install_all.sh
+++ b/build_and_install_all.sh
@@ -62,7 +62,7 @@ build() {
     rm -f "./$1/"*.pkg.tar.xz "./$1/"*.pkg.tar.xz.sig
     rm -f "./$1/"*.pkg.tar.zst "./$1/"*.pkg.tar.zst.sig
     # When building in a container, systemd's tests fail because of default Seccomp filters
-    if [ "$1" = 'systemd-selinux' ] && grep '^Seccomp:\s*2$' /proc/self/status > /dev/null
+    if [ "$1" = 'systemd-selinux' ] && [ -f /.dockerenv ]
     then
         set -- "$@" --nocheck
     fi


### PR DESCRIPTION
Here are some commits from https://github.com/archlinuxhardened/selinux/pull/83 and some modifications from me in order to :
* use `lsm=lockdown,yama,selinux,bpf`, which is the result of some tests (cf. https://github.com/archlinuxhardened/selinux/issues/81#issuecomment-775471636)
* keep `grep '^Seccomp:\s*2$' /proc/self/status > /dev/null` when detecting that `systemd-selinux` is being built in a "container". This helps building it in unprivileged containers which use seccomp but not `/.dockerenv` (such as `podman`)
* while at it, add options `-ex` to `bash` in the workflow configuration, so the job fails as soon as a command fails (before, errors were ignored)
* relabel all files in the VM (with `restorecon -RF /`). Otherwise many files were still unlabeled in the test VM.

This fixes https://github.com/archlinuxhardened/selinux/issues/81 and https://github.com/archlinuxhardened/selinux/issues/82.