### PR TITLE
GitHub Actions: upgrade to Ubuntu 20.04 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_all_packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: archlinux/archlinux:latest
       options: --security-opt=seccomp=unconfined
@@ -45,13 +45,13 @@ jobs:
           path: /packages
 
   prepare_testing:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: build_all_packages
     steps:
       - name: Install QEMU to the runner and make needed directories
         run: |
           sudo apt-get update
-          sudo apt-get install qemu
+          sudo apt-get install qemu-utils
           mkdir -v repo /tmp/{boots,arch}
 
       - name: Download latest ArchISO bootstrap image
@@ -126,7 +126,7 @@ jobs:
           path: archselinux.qcow2
 
   test_SELinux_functionality:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: prepare_testing
     steps:
       - uses: actions/checkout@v2
@@ -134,7 +134,7 @@ jobs:
       - name: Install QEMU to the runner and make needed directories
         run: |
           sudo apt-get update
-          sudo apt-get install qemu
+          sudo apt-get install qemu-system-x86 qemu-utils
 
       - name: Download VM artifact for testing
         uses: actions/download-artifact@v2
@@ -160,7 +160,7 @@ jobs:
           path: archselinux_test.qcow2
 
   prepare_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: test_SELinux_functionality
     steps:
       - name: Prepare Arch specific binaries for use
@@ -188,7 +188,7 @@ jobs:
           path: /tmp/boots/repo
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: prepare_release
     if: github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,13 +60,15 @@ jobs:
       - name: Create new raw image for Arch Linux and mount it as a loop device
         run: |
           qemu-img create -f raw archselinux.raw 8G
-          sudo losetup --show -f -P archselinux.raw
-          sudo parted /dev/loop0 mklabel msdos
-          sudo parted -a optimal /dev/loop0 mkpart primary 0% 100%
-          sudo parted /dev/loop0 set 1 boot on
-          sudo mkfs.ext4 /dev/loop0p1
-          sudo tune2fs -L ROOT /dev/loop0p1
-          sudo mount /dev/loop0p1 /tmp/arch
+          LOOP_DEVICE="$(sudo losetup --show -f -P archselinux.raw)"
+          echo "LOOP_DEVICE=${LOOP_DEVICE}" >> "$GITHUB_ENV"
+          echo "Using loop device ${LOOP_DEVICE}"
+          sudo parted "${LOOP_DEVICE}" mklabel msdos
+          sudo parted -a optimal "${LOOP_DEVICE}" mkpart primary 0% 100%
+          sudo parted "${LOOP_DEVICE}" set 1 boot on
+          sudo mkfs.ext4 "${LOOP_DEVICE}p1"
+          sudo tune2fs -L ROOT "${LOOP_DEVICE}p1"
+          sudo mount "${LOOP_DEVICE}p1" /tmp/arch
 
       - name: Get the SELinux packages from build job
         uses: actions/download-artifact@v2
@@ -81,7 +83,7 @@ jobs:
           sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -ex -c \
            'pacman-key --init;
             pacman-key --populate archlinux;
-            mount /dev/loop0p1 /mnt;
+            mount "'"${LOOP_DEVICE}p1"'" /mnt;
             echo "Server = https://mirror.pkgbuild.com/\$repo/os/\$arch" >> /etc/pacman.d/mirrorlist;
             echo -e "[selinux-testing]\nSigLevel = Never\nServer = file:///var/cache/pacman/pkg" >> /etc/pacman.conf;
             repo-add /var/cache/pacman/pkg/selinux-testing.db.tar.xz /var/cache/pacman/pkg/*;
@@ -104,7 +106,7 @@ jobs:
             sed -i "s/#PermitEmptyPasswords no/PermitEmptyPasswords yes/" /etc/ssh/sshd_config;
             systemctl enable sshd;
             sed -i 's/root:x:/root::/' /etc/passwd;
-            grub-install --target=i386-pc /dev/loop0;
+            grub-install --target=i386-pc "'"${LOOP_DEVICE}"'";
             sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/' /etc/default/grub;
             sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"lsm=lockdown,yama,selinux,bpf selinux=1 console=ttyS0\"" /etc/default/grub;
             grub-mkconfig -o /boot/grub/grub.cfg;
@@ -114,7 +116,7 @@ jobs:
         run: |
           sudo umount /tmp/boots/mnt
           sudo umount /tmp/arch
-          sudo losetup -d /dev/loop0
+          sudo losetup -d "${LOOP_DEVICE}"
           qemu-img convert -f raw -O qcow2 archselinux.raw archselinux.qcow2
 
       - name: Upload VM to artifacts


### PR DESCRIPTION
Using Ubuntu 20.04 in GitHub Actions requires installing `qemu-utils` in order to use command     `qemu-img`, and `qemu-system-x86` instead of `qemu`.

Moreover `/dev/loop0` cannot be directly used, so record the result of `losetup` in an environment variable and use it instead.