### PR TITLE
systemd-selinux 257.6-1

### DIFF
--- a/systemd-selinux/.SRCINFO
+++ b/systemd-selinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = systemd-selinux
-	pkgver = 257.5
-	pkgrel = 3
+	pkgver = 257.6
+	pkgrel = 1
 	url = https://www.github.com/systemd/systemd
 	arch = x86_64
 	arch = aarch64
@@ -57,7 +57,7 @@ pkgbase = systemd-selinux
 	makedepends = linux-headers
 	makedepends = libselinux
 	conflicts = mkinitcpio<38-1
-	source = git+https://github.com/systemd/systemd#tag=v257.5?signed
+	source = git+https://github.com/systemd/systemd#tag=v257.6?signed
 	source = 0001-Use-Arch-Linux-device-access-groups.patch
 	source = arch.conf
 	source = loader.conf
@@ -79,7 +79,7 @@ pkgbase = systemd-selinux
 	validpgpkeys = A9EA9081724FFAE0484C35A1A81CEA22BC8C7E2E
 	validpgpkeys = 9A774DB5DB996C154EBBFBFDA0099A18E29326E1
 	validpgpkeys = 5C251B5FC54EB2F80F407AAAC54CA336CFEB557E
-	sha512sums = 41b3a09f710a7801cec2d89a245c7ac06977aa91e133b72464179ab74c682f0a10320483ea48ebe774e0dc8d57bc453198cf91915d74ceda672379a4c06e77f8
+	sha512sums = 098f5800149b6d51c569ea33d126b7ce901a886b7fcebab26138089f1c33e1cf1e8489978e9ae724a568c5e198a5ebc3df3889ffaa0559a0a5332af4242d1837
 	sha512sums = 78065bde708118b7d6e4ed492e096c763e4679a1c54bd98750d5d609d8cc2f1373023f308880f14fc923ae7f9fea34824917ef884c0f996b1f43d08ef022c0fb
 	sha512sums = 61032d29241b74a0f28446f8cf1be0e8ec46d0847a61dadb2a4f096e8686d5f57fe5c72bcf386003f6520bc4b5856c32d63bf3efe7eb0bc0deefc9f68159e648
 	sha512sums = c416e2121df83067376bcaacb58c05b01990f4614ad9de657d74b6da3efa441af251d13bf21e3f0f71ddcb4c9ea658b81da3d915667dc5c309c87ec32a1cb5a5
@@ -105,7 +105,7 @@ pkgname = systemd-selinux
 	license = CC0-1.0
 	license = GPL-2.0-or-later
 	license = MIT-0
-	depends = systemd-libs-selinux=257.5
+	depends = systemd-libs-selinux=257.6
 	depends = acl
 	depends = libacl.so
 	depends = bash
@@ -153,9 +153,9 @@ pkgname = systemd-selinux
 	optdepends = libp11-kit: support PKCS#11
 	optdepends = tpm2-tss: unlocking LUKS2 volumes with TPM2
 	provides = nss-myhostname
-	provides = systemd-tools=257.5
-	provides = udev=257.5
-	provides = systemd=257.5-3
+	provides = systemd-tools=257.6
+	provides = udev=257.6
+	provides = systemd=257.6-1
 	conflicts = nss-myhostname
 	conflicts = systemd-tools
 	conflicts = udev
@@ -196,7 +196,7 @@ pkgname = systemd-libs-selinux
 	provides = libsystemd.so
 	provides = libudev.so
 	provides = libsystemd-selinux
-	provides = systemd-libs=257.5-3
+	provides = systemd-libs=257.6-1
 	conflicts = libsystemd
 	conflicts = libsystemd-selinux
 	conflicts = systemd-libs
@@ -204,34 +204,34 @@ pkgname = systemd-libs-selinux
 
 pkgname = systemd-resolvconf-selinux
 	pkgdesc = systemd resolvconf replacement with SELinux support (for use with systemd-resolved)
-	depends = systemd-selinux=257.5
+	depends = systemd-selinux=257.6
 	provides = openresolv
 	provides = resolvconf
-	provides = systemd-resolvconf=257.5-3
+	provides = systemd-resolvconf=257.6-1
 	conflicts = resolvconf
-	conflicts = systemd-resolvconf=257.5-3
+	conflicts = systemd-resolvconf=257.6-1
 
 pkgname = systemd-sysvcompat-selinux
 	pkgdesc = sysvinit compat for systemd with SELinux support
-	depends = systemd-selinux=257.5
-	provides = systemd-sysvcompat=257.5-3
-	provides = selinux-systemd-sysvcompat=257.5-3
+	depends = systemd-selinux=257.6
+	provides = systemd-sysvcompat=257.6-1
+	provides = selinux-systemd-sysvcompat=257.6-1
 	conflicts = sysvinit
 	conflicts = systemd-sysvcompat
 	conflicts = selinux-systemd-sysvcompat
 
 pkgname = systemd-tests-selinux
 	pkgdesc = systemd tests with SELinux support
-	depends = systemd-selinux=257.5
-	provides = systemd-tests=257.5-3
+	depends = systemd-selinux=257.6
+	provides = systemd-tests=257.6-1
 
 pkgname = systemd-ukify-selinux
 	pkgdesc = Combine kernel and initrd into a signed Unified Kernel Image with SELinux support
-	depends = systemd-selinux=257.5
+	depends = systemd-selinux=257.6
 	depends = binutils
 	depends = python-cryptography
 	depends = python-pefile
 	optdepends = python-pillow: Show the size of splash image
 	optdepends = sbsigntools: Sign the embedded kernel
 	provides = ukify
-	provides = systemd-ukify=257.5-3
+	provides = systemd-ukify=257.6-1

--- a/systemd-selinux/PKGBUILD
+++ b/systemd-selinux/PKGBUILD
@@ -24,8 +24,8 @@ pkgname=('systemd-selinux'
 # Upstream versioning is incompatible with pacman's version comparisons, one
 # way or another. We use proper version for pacman here (no dash for rc
 # release!), and change in source array below.
-pkgver='257.5'
-pkgrel=3
+pkgver='257.6'
+pkgrel=1
 arch=('x86_64' 'aarch64')
 license=('LGPL-2.1-or-later')
 url='https://www.github.com/systemd/systemd'
@@ -66,7 +66,7 @@ source=("git+https://github.com/systemd/systemd#tag=v${pkgver/rc/-rc}?signed"
         '30-systemd-tmpfiles.hook'
         '30-systemd-udev-reload.hook'
         '30-systemd-update.hook')
-sha512sums=('41b3a09f710a7801cec2d89a245c7ac06977aa91e133b72464179ab74c682f0a10320483ea48ebe774e0dc8d57bc453198cf91915d74ceda672379a4c06e77f8'
+sha512sums=('098f5800149b6d51c569ea33d126b7ce901a886b7fcebab26138089f1c33e1cf1e8489978e9ae724a568c5e198a5ebc3df3889ffaa0559a0a5332af4242d1837'
             '78065bde708118b7d6e4ed492e096c763e4679a1c54bd98750d5d609d8cc2f1373023f308880f14fc923ae7f9fea34824917ef884c0f996b1f43d08ef022c0fb'
             '61032d29241b74a0f28446f8cf1be0e8ec46d0847a61dadb2a4f096e8686d5f57fe5c72bcf386003f6520bc4b5856c32d63bf3efe7eb0bc0deefc9f68159e648'
             'c416e2121df83067376bcaacb58c05b01990f4614ad9de657d74b6da3efa441af251d13bf21e3f0f71ddcb4c9ea658b81da3d915667dc5c309c87ec32a1cb5a5'
@@ -103,11 +103,6 @@ fi
 #fi
 
 _backports=(
-  # fast-forward to current v257-stable
-  "v${pkgver}..1fb1f637baa979fd58fef67ea72b3e7255a99e21"
-
-  # backlight: Drop support for actual_brightness
-  '9a224c307b36610e3675390eb2620e74d0f4efb0'
 )
 
 _reverts=(
@@ -226,7 +221,6 @@ package_systemd-selinux() {
   optdepends=('libmicrohttpd: systemd-journal-gatewayd and systemd-journal-remote'
               'quota-tools: kernel-level quota management'
               'systemd-sysvcompat-selinux: symlink package to provide sysvinit binaries'
-              'systemd-ukify-selinux: combine kernel and initrd into a signed Unified Kernel Image'
               'polkit: allow administration as unprivileged user'
               'curl: systemd-journal-upload, machinectl pull-tar and pull-raw'
               'gnutls: systemd-journal-gatewayd and systemd-journal-remote'


### PR DESCRIPTION
I have modified the PKGBUILD and .SRCINFO files for the systemd package source in this repository so that they can build the latest version - 257.6 - with SELinux support.

Let me know if you would like a prebuilt package.

Thanks,
Stephen.