### PR TITLE
systemd: update to 257.9

### DIFF
--- a/systemd-selinux/.SRCINFO
+++ b/systemd-selinux/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = systemd-selinux
-	pkgver = 257.7
+	pkgver = 257.9
 	pkgrel = 1
 	url = https://www.github.com/systemd/systemd
 	arch = x86_64
@@ -57,7 +57,7 @@ pkgbase = systemd-selinux
 	makedepends = linux-headers
 	makedepends = libselinux
 	conflicts = mkinitcpio<38-1
-	source = git+https://github.com/systemd/systemd#tag=v257.7?signed
+	source = git+https://github.com/systemd/systemd#tag=v257.9?signed
 	source = 0001-Use-Arch-Linux-device-access-groups.patch
 	source = arch.conf
 	source = loader.conf
@@ -79,12 +79,12 @@ pkgbase = systemd-selinux
 	validpgpkeys = A9EA9081724FFAE0484C35A1A81CEA22BC8C7E2E
 	validpgpkeys = 9A774DB5DB996C154EBBFBFDA0099A18E29326E1
 	validpgpkeys = 5C251B5FC54EB2F80F407AAAC54CA336CFEB557E
-	sha512sums = 94c4f1fa540395653594d25a9633a47d2ce3053f0511b041b0ec73ddbb0db7877a50563be6c3ac3c9c5d1f5964b88a7de17f5fbd843e1391123ee6f0227fbd02
+	sha512sums = 27daa6035ef853ec802f8423c9d8d90810c2b0f71af2ec7d21d468905eacc109497e2186d15834856c006fea71cf9b96278d26a20e48bb212b7c049eac9fdd08
 	sha512sums = 78065bde708118b7d6e4ed492e096c763e4679a1c54bd98750d5d609d8cc2f1373023f308880f14fc923ae7f9fea34824917ef884c0f996b1f43d08ef022c0fb
 	sha512sums = 61032d29241b74a0f28446f8cf1be0e8ec46d0847a61dadb2a4f096e8686d5f57fe5c72bcf386003f6520bc4b5856c32d63bf3efe7eb0bc0deefc9f68159e648
 	sha512sums = c416e2121df83067376bcaacb58c05b01990f4614ad9de657d74b6da3efa441af251d13bf21e3f0f71ddcb4c9ea658b81da3d915667dc5c309c87ec32a1cb5a5
 	sha512sums = 5a1d78b5170da5abe3d18fdf9f2c3a4d78f15ba7d1ee9ec2708c4c9c2e28973469bc19386f70b3cf32ffafbe4fcc4303e5ebbd6d5187a1df3314ae0965b25e75
-	sha512sums = b90c99d768dc2a4f020ba854edf45ccf1b86a09d2f66e475de21fe589ff7e32c33ef4aa0876d7f1864491488fd7edb2682fc0d68e83a6d4890a0778dc2d6fe19
+	sha512sums = 32580b82e97573d3e499821e2ce415ff134c0ec52c9b44a3c0862c4007d347f55636d6afac3dfc6831a9b384c7448075bdf3a12f369b4d8b62b24dfdb9c8a76a
 	sha512sums = 81baa1ae439b0f4d1f09371a82c02db06a97a4fc35545fc2654f7905b4422fc8cf085f70304919a4323f39e662df1e05aa8d977d1dde73507527abe3072c386b
 	sha512sums = 299dcc7094ce53474521356647bdd2fb069731c08d14a872a425412fcd72da840727a23664b12d95465bf313e8e8297da31259508d1c62cc2dcea596160e21c5
 	sha512sums = 0d6bc3d928cfafe4e4e0bc04dbb95c5d2b078573e4f9e0576e7f53a8fab08a7077202f575d74a3960248c4904b5f7f0661bf17dbe163c524ab51dd30e3cb80f7
@@ -105,7 +105,7 @@ pkgname = systemd-selinux
 	license = CC0-1.0
 	license = GPL-2.0-or-later
 	license = MIT-0
-	depends = systemd-libs-selinux=257.7
+	depends = systemd-libs-selinux=257.9
 	depends = acl
 	depends = libacl.so
 	depends = bash
@@ -152,9 +152,9 @@ pkgname = systemd-selinux
 	optdepends = libp11-kit: support PKCS#11
 	optdepends = tpm2-tss: unlocking LUKS2 volumes with TPM2
 	provides = nss-myhostname
-	provides = systemd-tools=257.7
-	provides = udev=257.7
-	provides = systemd=257.7-1
+	provides = systemd-tools=257.9
+	provides = udev=257.9
+	provides = systemd=257.9-1
 	conflicts = nss-myhostname
 	conflicts = systemd-tools
 	conflicts = udev
@@ -195,7 +195,7 @@ pkgname = systemd-libs-selinux
 	provides = libsystemd.so
 	provides = libudev.so
 	provides = libsystemd-selinux
-	provides = systemd-libs=257.7-1
+	provides = systemd-libs=257.9-1
 	conflicts = libsystemd
 	conflicts = libsystemd-selinux
 	conflicts = systemd-libs
@@ -203,34 +203,34 @@ pkgname = systemd-libs-selinux
 
 pkgname = systemd-resolvconf-selinux
 	pkgdesc = systemd resolvconf replacement with SELinux support (for use with systemd-resolved)
-	depends = systemd-selinux=257.7
+	depends = systemd-selinux=257.9
 	provides = openresolv
 	provides = resolvconf
-	provides = systemd-resolvconf=257.7-1
+	provides = systemd-resolvconf=257.9-1
 	conflicts = resolvconf
-	conflicts = systemd-resolvconf=257.7-1
+	conflicts = systemd-resolvconf=257.9-1
 
 pkgname = systemd-sysvcompat-selinux
 	pkgdesc = sysvinit compat for systemd with SELinux support
-	depends = systemd-selinux=257.7
-	provides = systemd-sysvcompat=257.7-1
-	provides = selinux-systemd-sysvcompat=257.7-1
+	depends = systemd-selinux=257.9
+	provides = systemd-sysvcompat=257.9-1
+	provides = selinux-systemd-sysvcompat=257.9-1
 	conflicts = sysvinit
 	conflicts = systemd-sysvcompat
 	conflicts = selinux-systemd-sysvcompat
 
 pkgname = systemd-tests-selinux
 	pkgdesc = systemd tests with SELinux support
-	depends = systemd-selinux=257.7
-	provides = systemd-tests=257.7-1
+	depends = systemd-selinux=257.9
+	provides = systemd-tests=257.9-1
 
 pkgname = systemd-ukify-selinux
 	pkgdesc = Combine kernel and initrd into a signed Unified Kernel Image with SELinux support
-	depends = systemd-selinux=257.7
+	depends = systemd-selinux=257.9
 	depends = binutils
 	depends = python-cryptography
 	depends = python-pefile
 	optdepends = python-pillow: Show the size of splash image
 	optdepends = sbsigntools: Sign the embedded kernel
 	provides = ukify
-	provides = systemd-ukify=257.7-1
+	provides = systemd-ukify=257.9-1

--- a/systemd-selinux/PKGBUILD
+++ b/systemd-selinux/PKGBUILD
@@ -24,7 +24,7 @@ pkgname=('systemd-selinux'
 # Upstream versioning is incompatible with pacman's version comparisons, one
 # way or another. We use proper version for pacman here (no dash for rc
 # release!), and change in source array below.
-pkgver=257.7
+pkgver=257.9
 pkgrel=1
 arch=('x86_64' 'aarch64')
 license=('LGPL-2.1-or-later')
@@ -66,12 +66,12 @@ source=("git+https://github.com/systemd/systemd#tag=v${pkgver/rc/-rc}?signed"
         '30-systemd-tmpfiles.hook'
         '30-systemd-udev-reload.hook'
         '30-systemd-update.hook')
-sha512sums=('94c4f1fa540395653594d25a9633a47d2ce3053f0511b041b0ec73ddbb0db7877a50563be6c3ac3c9c5d1f5964b88a7de17f5fbd843e1391123ee6f0227fbd02'
+sha512sums=('27daa6035ef853ec802f8423c9d8d90810c2b0f71af2ec7d21d468905eacc109497e2186d15834856c006fea71cf9b96278d26a20e48bb212b7c049eac9fdd08'
             '78065bde708118b7d6e4ed492e096c763e4679a1c54bd98750d5d609d8cc2f1373023f308880f14fc923ae7f9fea34824917ef884c0f996b1f43d08ef022c0fb'
             '61032d29241b74a0f28446f8cf1be0e8ec46d0847a61dadb2a4f096e8686d5f57fe5c72bcf386003f6520bc4b5856c32d63bf3efe7eb0bc0deefc9f68159e648'
             'c416e2121df83067376bcaacb58c05b01990f4614ad9de657d74b6da3efa441af251d13bf21e3f0f71ddcb4c9ea658b81da3d915667dc5c309c87ec32a1cb5a5'
             '5a1d78b5170da5abe3d18fdf9f2c3a4d78f15ba7d1ee9ec2708c4c9c2e28973469bc19386f70b3cf32ffafbe4fcc4303e5ebbd6d5187a1df3314ae0965b25e75'
-            'b90c99d768dc2a4f020ba854edf45ccf1b86a09d2f66e475de21fe589ff7e32c33ef4aa0876d7f1864491488fd7edb2682fc0d68e83a6d4890a0778dc2d6fe19'
+            '32580b82e97573d3e499821e2ce415ff134c0ec52c9b44a3c0862c4007d347f55636d6afac3dfc6831a9b384c7448075bdf3a12f369b4d8b62b24dfdb9c8a76a'
             '81baa1ae439b0f4d1f09371a82c02db06a97a4fc35545fc2654f7905b4422fc8cf085f70304919a4323f39e662df1e05aa8d977d1dde73507527abe3072c386b'
             '299dcc7094ce53474521356647bdd2fb069731c08d14a872a425412fcd72da840727a23664b12d95465bf313e8e8297da31259508d1c62cc2dcea596160e21c5'
             '0d6bc3d928cfafe4e4e0bc04dbb95c5d2b078573e4f9e0576e7f53a8fab08a7077202f575d74a3960248c4904b5f7f0661bf17dbe163c524ab51dd30e3cb80f7'

--- a/systemd-selinux/systemd-user.pam
+++ b/systemd-selinux/systemd-user.pam
@@ -1,5 +1,10 @@
 # Used by systemd --user instances.
 
-account  include system-login
-session  required pam_loginuid.so
-session  include system-login
+account    include    system-login
+
+session    required   pam_loginuid.so
+session    optional   pam_keyinit.so       force revoke
+session    include    system-auth
+session    optional   pam_umask.so
+session    optional   pam_systemd.so
+session    required   pam_env.so


### PR DESCRIPTION
Hi there,

This PR updates systemd to version 257.9, which is the latest as of now.

One thing I noticed, that the `systemd-user.pam` file in this repository differs from the one found in upstream arch linux systemd sources. Is there a specific reason for this?
I have pulled the file from upstream instead.