### PR TITLE
feat: add GPG-signed Arch Linux package repository CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,191 @@
+name: Deploy Pages (Merged)
+
+on:
+  workflow_run:
+    workflows: [Build and Sign SELinux Repository]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  merge-and-deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download main-signed from nightly release
+        run: |
+          mkdir -p repo
+          gh release download nightly \
+            --repo ${{ github.repository }} \
+            -p 'selinux-repo-signed.tar.zst' \
+            -D repo/
+          cd repo && tar -xf selinux-repo-signed.tar.zst && rm -f *.tar.zst
+
+          # Generate package listing
+          cd main-signed
+          cat > packages.inc << 'PKGLIST'
+          <h2>Packages</h2>
+          <table>
+          <tr><th>Package</th><th>Version</th><th>Build Date</th><th>SHA256</th></tr>
+          PKGLIST
+          for pkg in x86_64/*.pkg.tar.zst; do
+            pkginfo=$(zstd -dc "$pkg" 2>/dev/null | tar -xO .PKGINFO 2>/dev/null)
+            pkgname=$(echo "$pkginfo" | grep '^pkgname =' | head -1 | cut -d' ' -f3)
+            pkgver=$(echo "$pkginfo" | grep '^pkgver =' | head -1 | cut -d' ' -f3)
+            builddate_ts=$(echo "$pkginfo" | grep '^builddate =' | head -1 | cut -d' ' -f3)
+            [ -n "$builddate_ts" ] && builddate=$(date -d @"$builddate_ts" +%Y-%m-%d 2>/dev/null) || builddate=$(date -d @$(stat --format=%Y "$pkg") +%Y-%m-%d)
+            sha256=$(sha256sum "$pkg" | cut -d' ' -f1)
+            echo "<tr><td>$pkgname</td><td>$pkgver</td><td>$builddate</td><td><code>$sha256</code></td></tr>" >> packages.inc
+          done
+          echo '</table>' >> packages.inc
+
+          cat > index.html << 'MAINEOF'
+          <!DOCTYPE html>
+          <html><head><meta charset=utf-8>
+          <title>main-signed — SELinux Arch repo</title>
+           <style>body{font-family:sans-serif;max-width:50rem;margin:2rem auto;padding:0 1rem;line-height:1.6}
+          a{color:#0366d6}code{background:#f6f8fa;padding:.2em .4em;border-radius:3px}
+          table{width:100%;border-collapse:collapse;margin:1em 0;font-size:.9em}
+          th,td{padding:.3em .6em;text-align:left;border-bottom:1px solid #ddd;word-break:break-all}
+          th{background:#f0f0f0}</style>
+          </head><body>
+          <h1>main-signed</h1>
+          <p>GPG-signed SELinux package repository. <a href="../">Back</a></p>
+          <h2>Usage</h2>
+          <pre>[main-signed]
+          SigLevel = Required
+          Server = https://lenucksi.github.io/selinux/main-signed/$arch</pre>
+          <h2>Install signing key</h2>
+          <pre>pacman-key --add https://lenucksi.github.io/selinux/main-signed/x86_64/public.asc
+          pacman-key --lsign-key A66EAD29600BEF3A2F09B945EB8AEC2BA4B6DC1F</pre>
+          <!-- PACKAGES -->
+          </body></html>
+          MAINEOF
+          sed -i '/<!-- PACKAGES -->/{
+            r packages.inc
+            d
+          }' index.html
+          rm packages.inc
+          cd ../..
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download hello-world from nightly-hello-world (optional)
+        run: |
+          if gh release download nightly-hello-world \
+            --repo ${{ github.repository }} \
+            -p '*.tar.zst' \
+            -D repo/ 2>/dev/null; then
+            cd repo && tar -xf hello-go-repo-signed.tar.zst && rm -f *.tar.zst
+            mv go-hello-world hello-world
+
+            # Create real db.sig copies for SigLevel = Required (Pages doesn't follow symlinks)
+            cd hello-world/x86_64
+            cp go-hello-world.db.tar.zst.sig go-hello-world.db.sig
+            cp go-hello-world.files.tar.zst.sig go-hello-world.files.sig
+            cd ..
+
+            # Generate package listing
+            cat > packages.inc << 'PKGLIST'
+          <h2>Packages</h2>
+          <table>
+          <tr><th>Package</th><th>Version</th><th>Build Date</th><th>SHA256</th></tr>
+          PKGLIST
+            for pkg in x86_64/*.pkg.tar.zst; do
+              pkginfo=$(zstd -dc "$pkg" 2>/dev/null | tar -xO .PKGINFO 2>/dev/null)
+              pkgname=$(echo "$pkginfo" | grep '^pkgname =' | head -1 | cut -d' ' -f3)
+              pkgver=$(echo "$pkginfo" | grep '^pkgver =' | head -1 | cut -d' ' -f3)
+              builddate_ts=$(echo "$pkginfo" | grep '^builddate =' | head -1 | cut -d' ' -f3)
+              [ -n "$builddate_ts" ] && builddate=$(date -d @"$builddate_ts" +%Y-%m-%d 2>/dev/null) || builddate=$(date -d @$(stat --format=%Y "$pkg") +%Y-%m-%d)
+              sha256=$(sha256sum "$pkg" | cut -d' ' -f1)
+              echo "<tr><td>$pkgname</td><td>$pkgver</td><td>$builddate</td><td><code>$sha256</code></td></tr>" >> packages.inc
+            done
+            echo '</table>' >> packages.inc
+
+            cat > index.html << 'HELLOEOF'
+          <!DOCTYPE html>
+          <html><head><meta charset=utf-8>
+          <title>hello-world — PoC signed repo</title>
+          <style>body{font-family:sans-serif;max-width:50rem;margin:2rem auto;padding:0 1rem;line-height:1.6}
+          a{color:#0366d6}code{background:#f6f8fa;padding:.2em .4em;border-radius:3px}
+          table{width:100%;border-collapse:collapse;margin:1em 0;font-size:.9em}
+          th,td{padding:.3em .6em;text-align:left;border-bottom:1px solid #ddd;word-break:break-all}
+          th{background:#f0f0f0}</style>
+          </head><body>
+          <h1>hello-world</h1>
+          <p>PoC GPG-signed package repository. <a href="../">Back</a></p>
+          <h2>Usage</h2>
+          <pre>[go-hello-world]
+          SigLevel = Required
+          Server = https://lenucksi.github.io/selinux/hello-world/$arch</pre>
+          <h2>Install signing key</h2>
+          <pre>pacman-key --add https://lenucksi.github.io/selinux/hello-world/x86_64/public.asc
+          pacman-key --lsign-key A66EAD29600BEF3A2F09B945EB8AEC2BA4B6DC1F</pre>
+          <!-- PACKAGES -->
+          </body></html>
+          HELLOEOF
+            sed -i '/<!-- PACKAGES -->/{
+              r packages.inc
+              d
+            }' index.html
+            rm packages.inc
+            cd ..
+            echo "hello-world ready"
+          else
+            echo "no hello-world release — continuing without it"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create landing page
+        run: |
+          cat > repo/index.html << 'INDEXEOF'
+          <!DOCTYPE html>
+          <html><head><meta charset=utf-8>
+          <title>SELinux Arch Linux Repository</title>
+          <style>body{font-family:sans-serif;max-width:50rem;margin:2rem auto;padding:0 1rem;line-height:1.6}
+          a{color:#0366d6}code{background:#f6f8fa;padding:.2em .4em;border-radius:3px}</style>
+          </head><body>
+          <h1>SELinux Arch Linux Repository</h1>
+          <p>GPG-signed Arch Linux package repository for SELinux support.</p>
+          <h2>Repositories</h2>
+          <ul>
+          <li><a href="hello-world/">hello-world</a> — PoC signed repo</li>
+          <li><a href="main-signed/">main-signed</a> — Full SELinux signed repo</li>
+          </ul>
+          <h2>Usage</h2>
+          <pre>
+          [selinux]
+          SigLevel = Required
+          Server = https://lenucksi.github.io/selinux/main-signed/$arch
+
+          [go-hello-world]
+          SigLevel = Required
+          Server = https://lenucksi.github.io/selinux/hello-world/$arch</pre>
+          <h2>Install signing key</h2>
+          <pre>
+          curl -O https://lenucksi.github.io/selinux/main-signed/x86_64/public.asc
+          sudo pacman-key --add public.asc
+          sudo pacman-key --lsign-key A66EAD29600BEF3A2F09B945EB8AEC2BA4B6DC1F</pre>
+          </body></html>
+          INDEXEOF
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: repo
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -166,7 +166,7 @@ jobs:
           </ul>
           <h2>Usage</h2>
           <pre>
-          [selinux]
+          [main-signed]
           SigLevel = Required
           Server = https://lenucksi.github.io/selinux/main-signed/$arch
 

--- a/.github/workflows/hello-go.yml
+++ b/.github/workflows/hello-go.yml
@@ -1,0 +1,229 @@
+name: Build and Deploy hello-go
+
+on:
+  workflow_call:
+  push:
+    branches: [master]
+    paths:
+      - 'hello-go/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hello-go-pages
+  cancel-in-progress: false
+
+jobs:
+
+  # ──────────────────────────────────────────────
+  # Job 1: Build (Container, kein GPG)
+  # ──────────────────────────────────────────────
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+      options: --privileged
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Setup build user
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm base-devel go go-tools
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chown -R builder:builder .
+          mkdir -p /packages
+          chmod 777 /packages
+
+      - name: Build package (unsigned)
+        run: |
+          cd hello-go
+          sudo -u builder PKGDEST=/packages makepkg --clean --noconfirm
+
+      - name: Upload unsigned packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hello-go-unsigned
+          path: /packages/
+          retention-days: 1
+
+  # ──────────────────────────────────────────────
+  # Job 2: Sign (Runner, kein Container, GPG aktiv)
+  # ──────────────────────────────────────────────
+  sign:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Download unsigned packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: hello-go-unsigned
+          path: /tmp/packages
+
+      - name: Sign packages with GPG
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd /tmp/packages
+          for pkg in *.pkg.tar.zst; do
+            echo "Signing: $pkg"
+            gpg --batch --detach-sign -u "$GPGKEY" \
+              --pinentry-mode loopback --passphrase-fd 0 \
+              --output "${pkg}.sig" --sign "${pkg}" <<< "$PASSPHRASE"
+          done
+          ls -la
+
+      - name: Upload signed packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hello-go-signed
+          path: /tmp/packages/
+          retention-days: 1
+
+  # ──────────────────────────────────────────────
+  # Job 3: Create Repo (Container, kein GPG)
+  # ──────────────────────────────────────────────
+  create-repo:
+    runs-on: ubuntu-latest
+    needs: sign
+    container:
+      image: archlinux:base-devel
+      options: --privileged
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Download signed packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: hello-go-signed
+          path: /packages
+
+      - name: Create repo structure
+        run: |
+          mkdir -p repo/go-hello-world/x86_64
+          cp /packages/*.pkg.tar.zst* repo/go-hello-world/x86_64/
+          cp public.asc repo/go-hello-world/x86_64/
+          cd repo/go-hello-world/x86_64
+           repo-add --include-sigs go-hello-world.db.tar.zst *.pkg.tar.zst
+           ln -sf go-hello-world.db.tar.zst go-hello-world.db
+           ln -sf go-hello-world.files.tar.zst go-hello-world.files
+           {
+            echo '<!DOCTYPE html>'
+            echo '<html><head><meta charset=utf-8>'
+            echo '<title>go-hello-world -- signed Arch repo</title>'
+            echo '<style>body{font-family:sans-serif;max-width:50rem;margin:2rem auto;padding:0 1rem;line-height:1.6}'
+            echo 'a{color:#0366d6}code{background:#f6f8fa;padding:.2em .4em;border-radius:3px}</style>'
+            echo '</head><body>'
+            echo '<h1>go-hello-world</h1>'
+            echo '<p>GPG-signed Arch Linux package repository -- PoC.</p>'
+            echo '<h2>Add to /etc/pacman.conf</h2>'
+            echo '<pre>[go-hello-world]'
+            echo 'SigLevel = Required DatabaseOptional'
+            echo 'Server = https://lenucksi.github.io/selinux/go-hello-world/$arch'
+            echo '</pre>'
+            echo '<h2>Install signing key</h2>'
+            echo '<pre>pacman-key --add https://lenucksi.github.io/selinux/go-hello-world/x86_64/public.asc'
+            echo 'pacman-key --lsign-key A66EAD29600BEF3A2F09B945EB8AEC2BA4B6DC1F</pre>'
+            echo '<h2>Install</h2>'
+            echo '<pre>pacman -Sy hello-go</pre>'
+            echo '</body></html>'
+          } > ../../index.html
+          ls -la ../../
+
+      - name: Upload repo directory
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: repo-dir
+          path: repo/
+          retention-days: 1
+
+  # ──────────────────────────────────────────────
+  # Job 4: Sign DB + Upload artifact (Runner, GPG aktiv)
+  # ──────────────────────────────────────────────
+  sign-db:
+    runs-on: ubuntu-latest
+    needs: create-repo
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Download repo directory
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: repo-dir
+          path: repo
+
+      - name: Sign database files
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd repo/go-hello-world/x86_64
+          for db in *.db.tar.zst *.files.tar.zst; do
+            echo "Signing database: $db"
+            gpg --batch --detach-sign -u "$GPGKEY" \
+              --pinentry-mode loopback --passphrase-fd 0 \
+              --output "${db}.sig" --sign "${db}" <<< "$PASSPHRASE"
+          done
+          ls -la
+
+      - name: Verify all signatures
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+        run: |
+          cd repo/go-hello-world/x86_64
+          for pkg in hello-go-*.pkg.tar.zst; do
+            gpg --verify "${pkg}.sig" "${pkg}" || exit 1
+          done
+          for db in *.db.tar.zst *.files.tar.zst; do
+            gpg --verify "${db}.sig" "${db}" || exit 1
+          done
+           echo "All signatures verified"
+
+      - name: Create real db.sig copies (Pages doesn't follow symlinks)
+        run: |
+          cd repo/go-hello-world/x86_64
+          cp go-hello-world.db.tar.zst.sig go-hello-world.db.sig
+          cp go-hello-world.files.tar.zst.sig go-hello-world.files.sig
+
+      - name: Upload signed repo artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hello-go-repo-dir
+          path: repo/
+          retention-days: 1
+
+      - name: Publish nightly-hello-world release
+        run: |
+          tar -acf hello-go-repo-signed.tar.zst -C repo go-hello-world/
+          gh release delete nightly-hello-world --cleanup-tag --yes \
+            --repo ${{ github.repository }} 2>/dev/null || true
+          gh release create nightly-hello-world \
+            --repo ${{ github.repository }} \
+            --title "Nightly Hello-World — $(date +'%Y-%m-%d')" \
+            --prerelease \
+            --notes "Commit: ${{ github.sha }}" \
+            hello-go-repo-signed.tar.zst
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main-signed.yml
+++ b/.github/workflows/main-signed.yml
@@ -1,0 +1,397 @@
+name: Build and Sign SELinux Repository
+
+on:
+  workflow_call:
+  push:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-signed
+  cancel-in-progress: false
+
+env:
+  GPG_FINGERPRINT: A66EAD29600BEF3A2F09B945EB8AEC2BA4B6DC1F
+  REPO_NAME: main-signed
+
+jobs:
+
+  # ═══════════════════════════════════════════════════
+  # Job 1: Build (Container, kein GPG)
+  # ═══════════════════════════════════════════════════
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux/archlinux:latest
+      options: --security-opt=seccomp=unconfined
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Setup build environment
+        run: |
+          mkdir -vp /startdir
+          cp -Rv . /startdir
+          pacman -q --noconfirm -Syu base base-devel expect git
+          pacman --noconfirm -Sc
+          rm -rf /var/cache/pacman/pkg/*
+          ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+          useradd -g users -m builduser
+          echo 'builduser ALL=(ALL) NOPASSWD: /usr/bin/pacman' >> /etc/sudoers
+          echo 'builduser ALL=(ALL) NOPASSWD: /usr/bin/sh -c { pacman --noconfirm --ask=4 -U sudo-selinux/sudo-selinux-*.pkg.tar.zst && if test -e /etc/sudoers.pacsave ; then mv /etc/sudoers.pacsave /etc/sudoers ; fi }' >> /etc/sudoers
+          echo 'MAKEFLAGS="-j$(nproc)"' >> /etc/makepkg.conf
+          echo 'BUILDDIR=/build' >> /etc/makepkg.conf
+          echo 'LOGDEST=/logdest' >> /etc/makepkg.conf
+          echo 'SRCDEST=/sources' >> /etc/makepkg.conf
+          mkdir -vp /packages /build /logdest /sources
+          chown -R builduser /startdir /packages /build /logdest /sources
+
+      - name: Cache VCS sources (bare git mirrors in SRCDEST)
+        id: cache-sources
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /sources
+          key: vcs-sources-${{ github.sha }}
+          restore-keys: vcs-sources-
+
+      - name: Build all packages (unsigned)
+        run: |
+          cd /startdir
+          sudo -u builduser /startdir/clean.sh
+          sudo -u builduser /startdir/recv_gpg_keys.sh
+          sudo -u builduser git config --global http.postBuffer 536870912
+          sudo -u builduser /startdir/build_and_install_all.sh
+          rm -rf /startdir/*/src/ /startdir/*/pkg/
+          pacman --noconfirm -Sc
+          rm -rf /var/cache/pacman/pkg/*
+
+      - name: Collect packages
+        run: |
+          cp /startdir/*/*.pkg.tar.zst /packages/
+          ls -la /packages/
+
+      - name: Upload unsigned packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: selinux-packages-unsigned
+          path: /packages/
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════
+  # Job 2: Sign (Runner, GPG aktiv)
+  # ═══════════════════════════════════════════════════
+  sign:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Download unsigned packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: selinux-packages-unsigned
+          path: /tmp/packages
+
+      - name: Sign packages with GPG
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd /tmp/packages
+          for pkg in *.pkg.tar.zst; do
+            echo "Signing: $pkg"
+            gpg --batch --detach-sign -u "$GPGKEY" \
+              --pinentry-mode loopback --passphrase-fd 0 \
+              --output "${pkg}.sig" --sign "${pkg}" <<< "$PASSPHRASE"
+          done
+          ls -la
+
+      - name: Upload signed packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: selinux-packages-signed
+          path: /tmp/packages/
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════
+  # Job 3: Create Repo (Container, kein GPG)
+  # ═══════════════════════════════════════════════════
+  create-repo:
+    runs-on: ubuntu-latest
+    needs: sign
+    container:
+      image: archlinux:base-devel
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Install repo tools
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm pacman-contrib
+
+      - name: Download signed packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: selinux-packages-signed
+          path: /packages
+
+      - name: Create repo structure
+        run: |
+          mkdir -p repo/${{ env.REPO_NAME }}/x86_64
+          cp /packages/*.pkg.tar.zst* repo/${{ env.REPO_NAME }}/x86_64/
+          cp public.asc repo/${{ env.REPO_NAME }}/x86_64/
+           cd repo/${{ env.REPO_NAME }}/x86_64
+           repo-add --include-sigs ${{ env.REPO_NAME }}.db.tar.zst *.pkg.tar.zst
+           ln -sf ${{ env.REPO_NAME }}.db.tar.zst ${{ env.REPO_NAME }}.db
+           ln -sf ${{ env.REPO_NAME }}.files.tar.zst ${{ env.REPO_NAME }}.files
+           ls -la
+
+      - name: Upload repo directory (unsigned DB)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: selinux-repo-unsigned-db
+          path: repo/
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════
+  # Job 4: Sign DB (Runner, GPG aktiv)
+  # ═══════════════════════════════════════════════════
+  sign-db:
+    runs-on: ubuntu-latest
+    needs: create-repo
+    permissions:
+      contents: write
+
+    steps:
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Download repo directory
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: selinux-repo-unsigned-db
+          path: repo
+
+      - name: Sign database files
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd repo/${{ env.REPO_NAME }}/x86_64
+          for db in *.db.tar.zst *.files.tar.zst; do
+            echo "Signing database: $db"
+            gpg --batch --detach-sign -u "$GPGKEY" \
+              --pinentry-mode loopback --passphrase-fd 0 \
+              --output "${db}.sig" --sign "${db}" <<< "$PASSPHRASE"
+          done
+          ls -la
+
+      - name: Verify all signatures
+        env:
+          GPGKEY: ${{ steps.gpg.outputs.fingerprint }}
+        run: |
+          cd repo/${{ env.REPO_NAME }}/x86_64
+          for pkg in *.pkg.tar.zst; do
+            gpg --verify "${pkg}.sig" "${pkg}" || exit 1
+          done
+          for db in *.db.tar.zst *.files.tar.zst; do
+            gpg --verify "${db}.sig" "${db}" || exit 1
+          done
+           echo "All signatures verified"
+
+      - name: Create real db.sig copies (Pages doesn't follow symlinks)
+        run: |
+          cd repo/${{ env.REPO_NAME }}/x86_64
+          cp ${{ env.REPO_NAME }}.db.tar.zst.sig ${{ env.REPO_NAME }}.db.sig
+          cp ${{ env.REPO_NAME }}.files.tar.zst.sig ${{ env.REPO_NAME }}.files.sig
+
+      - name: Upload fully signed repo
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: selinux-repo-fully-signed
+          path: repo/
+          retention-days: 3
+
+      - name: Publish nightly release
+        run: |
+          tar -acf selinux-repo-signed.tar.zst -C repo main-signed/
+          gh release delete nightly --cleanup-tag --yes \
+            --repo ${{ github.repository }} 2>/dev/null || true
+          gh release create nightly \
+            --repo ${{ github.repository }} \
+            --title "Nightly SELinux Build — $(date +'%Y-%m-%d')" \
+            --prerelease \
+            --notes "Commit: ${{ github.sha }}" \
+            selinux-repo-signed.tar.zst
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ═══════════════════════════════════════════════════
+  # Job 5: Prepare VM Testing (Runner)
+  # ═══════════════════════════════════════════════════
+  prepare-testing:
+    runs-on: ubuntu-latest
+    needs: sign-db
+
+    steps:
+      - name: Install QEMU and tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-utils
+
+      - name: Make directories
+        run: |
+          mkdir -v repo /tmp/{boots,arch}
+
+      - name: Download ArchISO bootstrap
+        run: |
+          echo "Downloading archlinux-bootstrap-x86_64.tar.zst"
+          curl -LO "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.zst"
+
+      - name: Create raw disk image
+        run: |
+          qemu-img create -f raw archselinux.raw 8G
+          LOOP_DEVICE="$(sudo losetup --show -f -P archselinux.raw)"
+          echo "LOOP_DEVICE=${LOOP_DEVICE}" >> "$GITHUB_ENV"
+          echo "Using loop device ${LOOP_DEVICE}"
+          sudo parted "${LOOP_DEVICE}" mklabel msdos
+          sudo parted -a optimal "${LOOP_DEVICE}" mkpart primary 0% 100%
+          sudo parted "${LOOP_DEVICE}" set 1 boot on
+          sudo mkfs.ext4 "${LOOP_DEVICE}p1"
+          sudo tune2fs -L ROOT "${LOOP_DEVICE}p1"
+          sudo mount "${LOOP_DEVICE}p1" /tmp/arch
+
+      - name: Download fully signed repo
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: selinux-repo-fully-signed
+          path: repo
+
+      - name: Prepare bootstrap with signed packages
+        run: |
+          sudo tar xf archlinux-bootstrap-x86_64.tar.zst -C /tmp/boots --strip-components 1
+          # Copy full repo tree to /srv/main-signed/ (same layout as GH Pages deploy)
+          sudo mkdir -p /tmp/boots/srv
+          sudo cp -vr repo/${{ env.REPO_NAME }} /tmp/boots/srv/
+
+          # Detect key ID from public key
+          KEY_ID=$(gpg --show-keys --with-colons repo/${{ env.REPO_NAME }}/x86_64/public.asc | awk -F: '/^pub/{print $5}')
+
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/boots /bin/bash -ex -c "
+            pacman-key --init
+            pacman-key --populate archlinux
+            mount '${LOOP_DEVICE}p1' /mnt
+            echo 'Server = https://geo.mirror.pkgbuild.com/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
+            sed -i -e 's/^CheckSpace/#CheckSpace/' /etc/pacman.conf
+
+            # Import and trust our signing key (from repo tree, not /var/cache/pacman/pkg)
+            pacman-key --add /srv/main-signed/x86_64/public.asc
+            pacman-key --lsign-key ${KEY_ID}
+
+            # Use fully-signed repo from /srv/main-signed/ -- DB + sigs already bundled
+            echo -e '[main-signed]\nSigLevel = Required DatabaseOptional\nServer = file:///srv/main-signed/\$arch' >> /etc/pacman.conf
+
+            # Install SELinux system
+            pacman --noconfirm -Sy archlinux-keyring
+            rm /var/cache/pacman/pkg/archlinux-keyring*
+            pacstrap /mnt base-selinux base-devel-selinux openssh-selinux linux grub
+            genfstab -L /mnt >> /mnt/etc/fstab
+          " || exit 1
+
+      - name: Configure the VM image
+        run: |
+          sudo /tmp/boots/usr/bin/arch-chroot /tmp/arch /bin/bash -ex -c '
+            ln -sfv /usr/share/zoneinfo/UTC /etc/localtime
+            hwclock --systohc
+            sed -i "s/#en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen
+            locale-gen
+            echo LANG=en_US.UTF-8 > /etc/locale.conf
+            echo qemu-arch-selinux > /etc/hostname
+            echo -e "127.0.0.1 localhost\n::1 localhost" > /etc/hosts
+            echo -e "[Match]\nName=en*\n[Network]\nDHCP=ipv4" > /etc/systemd/network/dhcp.network
+            systemctl enable systemd-networkd.service
+            sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config
+            sed -i "s/#PermitEmptyPasswords no/PermitEmptyPasswords yes/" /etc/ssh/sshd_config
+            systemctl enable sshd
+            sed -i "s/root:x:/root::/" /etc/passwd
+            touch /etc/vconsole.conf
+            sed -i "s/^MODULES=()/MODULES=(ata_piix)/" -i /etc/mkinitcpio.conf
+            mkinitcpio -p linux
+            grub-install --target=i386-pc '${LOOP_DEVICE}'
+            sed -i "s/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/" /etc/default/grub
+            sed -i "/LINUX_DEF/c\GRUB_CMDLINE_LINUX_DEFAULT=\"lsm=lockdown,yama,selinux,bpf selinux=1 console=ttyS0\"" /etc/default/grub
+            grub-mkconfig -o /boot/grub/grub.cfg
+            restorecon -RF /
+          '
+
+      - name: Convert image to qcow2
+        run: |
+          sudo umount /tmp/boots/mnt
+          sudo umount /tmp/arch
+          sudo losetup -d "${LOOP_DEVICE}"
+          qemu-img convert -f raw -O qcow2 archselinux.raw archselinux.qcow2
+
+      - name: Upload VM image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arch-selinux-vm
+          path: archselinux.qcow2
+
+  # ═══════════════════════════════════════════════════
+  # Job 6: Test SELinux Functionality (Runner)
+  # ═══════════════════════════════════════════════════
+  test:
+    runs-on: ubuntu-latest
+    needs: prepare-testing
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-x86 qemu-utils
+
+      - name: Download VM image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: arch-selinux-vm
+
+      - name: Create backing file for test
+        run: |
+          qemu-img create -f qcow2 -F qcow2 -b archselinux.qcow2 archselinux_test.qcow2
+
+      - name: Boot VM and run tests
+        run: |
+          qemu-system-x86_64 archselinux_test.qcow2 \
+            -net nic -net user,hostfwd=tcp::10022-:22 \
+            -nographic -m 2048 &
+          sleep 25
+          for TRY_COUNT in $(seq 5); do
+            if timeout 60 ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 true; then
+              break
+            fi
+            echo "Failed to connect after $TRY_COUNT attempts, retrying..."
+            sleep 10
+          done
+          ssh -o "StrictHostKeyChecking=no" root@localhost -p 10022 \
+            'restorecon -Rv /; ls -laZ /; sestatus'


### PR DESCRIPTION
# feat: add GPG-signed Arch Linux package repository CI/CD pipeline

This PR adds three GitHub Actions workflows that build, GPG-sign, and deploy
Arch Linux SELinux packages to GitHub Pages as a fully signed pacman repository.

Result can be seen here: https://lenucksi.github.io/selinux/

## Workflows

### 1. `hello-go.yml` — PoC signed repository (229 lines)

A minimal end-to-end signed repository workflow for a single `hello-go` package.
- Builds `hello-go` + `hello-go-debug` packages
- Signs packages and DB with GPG
- Publishes `nightly-hello-world` prerelease with tarball
- Demonstrates the full pipeline pattern in a compact workflow

**Trigger:** `push` to `hello-go/**`, `workflow_dispatch`, or `workflow_call`

### 2. `main-signed.yml` — Full SELinux signed repository (397 lines)

The main production workflow that builds all SELinux packages.
- **Job 1 (build):** Builds all 60+ SELinux packages in an Arch Linux container
  using `build_and_install_all.sh`, with SRCDEST/actions/cache for VCS source
  reuse and `--holdver` to avoid git refetch on repeated builds
- **Job 2 (sign):** Signs each `.pkg.tar.zst` with GPG on the host runner
- **Job 3 (create-repo):** Runs `repo-add --include-sigs` to create the
  pacman database, adds `.db`/`.files` symlinks for compat, uploads to artifact
- **Job 4 (sign-db):** GPG-signs the `*.db.tar.zst` and `*.files.tar.zst`,
  creates real copies of `.db.sig`/`.files.sig` (GitHub Pages doesn't follow
  symlinks), publishes `nightly` prerelease with tarball
- **Job 5 (prepare-testing):** Bootstraps a VM image with the signed repo,
  installs the SELinux system, runs `restorecon` and `sestatus`
- **Job 6 (test):** Boots the VM under QEMU, SSH in, verifies SELinux status

**Trigger:** `push` to `master`, `workflow_dispatch`, `schedule` (weekly),
or `workflow_call`

### 3. `deploy-pages.yml` — GitHub Pages deployment (191 lines)

Triggered by `workflow_run` on `main-signed.yml` success (or `workflow_dispatch`).
- Downloads `nightly` (main-signed) and optionally `nightly-hello-world` releases
- Extracts tarballs, renames `go-hello-world` → `hello-world`
- Generates `index.html` for each repo directory with package listing tables
- Creates landing page at repo root with pacman config instructions
- Generates `.db.sig` copies (real files, not symlinks)
- Uploads to GitHub Pages via `upload-pages-artifact`

## Required Configuration

### 1. GitHub Pages

Enable GitHub Pages for the repository:
- **Settings → Pages → Source**: "GitHub Actions"
- URLs in `index.html` templates reference `https://<owner>.github.io/<repo>/`
  — update if using a different Pages setup

### 2. GPG Key

The signing key should be an **Ed25519** key (small, fast, modern):

```bash
gpg --full-generate-key --key-type ed25519 --expire 0
gpg --export-secret-key --armor <KEY-ID> > private.asc
```

Add to repository secrets:
- `GPG_PRIVATE_KEY`: the full ASCII-armored private key
- `GPG_PASSPHRASE`: the key's passphrase

The public key is exported automatically during the workflow and placed
in each repo's `x86_64/public.asc` for user import via `pacman-key --add`.

### 3. Workflow Permissions

Settings → Actions → General → Workflow permissions:
- ✅ Read and write permissions
- ✅ Allow GitHub Actions to create and approve pull requests

`GITHUB_TOKEN` is sufficient — no additional tokens needed.

## Getting Started

1. Generate an Ed25519 GPG key pair
2. Add `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` to repository secrets
3. Enable GitHub Pages (GitHub Actions source)
4. Push a commit to `master` or trigger `main-signed.yml` via `workflow_dispatch`
5. After `main-signed.yml` completes, `deploy-pages.yml` will deploy to Pages

The `hello-go.yml` workflow can be tested independently (triggers on
`hello-go/**` pushes) — useful for verifying the GPG setup without
building all 60+ packages.

## Key Decisions

- **Nightly releases over CI artifacts**: `gh release create nightly` with
  `--prerelease` + `--cleanup-tag`. Single tarball per release avoids artifact
  retention limits and makes external consumption possible.
- **Pure `gh release` CLI**: No third-party release actions.
  `--repo ${{ github.repository }}` used in jobs without git context
  (e.g. `workflow_run`).
- **`SigLevel = Required`**: DB signing enforced via `.db.sig` files.
  Users must `pacman-key --lsign-key` the repo key. Stricter than Arch's
  own `DatabaseOptional` default but viable for a controlled signing setup.
- **Real copies, not symlinks**: GitHub Pages serves symlinks as their text
  content (the target path string), not the target file. `.db.sig`/`.files.sig`
  are created as real file copies after GPG signing.
- **Arch containers**: Build jobs run in `archlinux:base-devel` containers.
  GPG signing runs on the host runner where `gpg` has access to `$HOME/.gnupg`.
